### PR TITLE
Fixes the view positions across the 3 variants

### DIFF
--- a/787-10-GEnx-set.xml
+++ b/787-10-GEnx-set.xml
@@ -213,7 +213,7 @@
         <internal type="bool">true</internal>
         <cockpit type="bool">true</cockpit>
         <config>
-            <x-offset-m type="double">-0.603</x-offset-m>
+            <x-offset-m type="double">-0.568</x-offset-m>
             <y-offset-m type="double">2.242</y-offset-m>
             <z-offset-m type="double">-28.872</z-offset-m>
             <pitch-offset-deg>-10.3</pitch-offset-deg>
@@ -343,7 +343,7 @@
             <back-right-direction-deg type="double">225</back-right-direction-deg>
             <right-direction-deg type="double">270</right-direction-deg>
             <front-right-direction-deg type="double">315</front-right-direction-deg>
-            <x-offset-m type="double">0.603</x-offset-m>
+            <x-offset-m type="double">0.568</x-offset-m>
             <y-offset-m type="double">2.242</y-offset-m>
             <z-offset-m type="double">-28.872</z-offset-m>
             <pitch-offset-deg>-10.3</pitch-offset-deg>

--- a/787-10-GEnx-set.xml
+++ b/787-10-GEnx-set.xml
@@ -206,17 +206,18 @@
             <master-caution type="bool">false</master-caution>
         </alarms>
 
+    <!-- The cockpit is -6.26 z-offset from the cockpit of the 787-8 -->
     <view n="0">
         <name>Pilot View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
         <cockpit type="bool">true</cockpit>
         <config>
-            <x-offset-m type="double">-0.57</x-offset-m>
-            <y-offset-m type="double">2.3</y-offset-m>
-            <z-offset-m type="double">-28.6</z-offset-m>
+            <x-offset-m type="double">-0.603</x-offset-m>
+            <y-offset-m type="double">2.242</y-offset-m>
+            <z-offset-m type="double">-28.872</z-offset-m>
             <pitch-offset-deg>-10.3</pitch-offset-deg>
-            <default-field-of-view-deg type="double">60.0</default-field-of-view-deg>
+            <default-field-of-view-deg type="double">90.0</default-field-of-view-deg>
         </config>
     </view>
 
@@ -252,6 +253,7 @@
             <z-offset-m archive="y" type="double">125.0</z-offset-m>
         </config>
     </view>
+
     <view n="101">
         <name>Gear View</name>
         <type>lookfrom</type>
@@ -263,7 +265,7 @@
             <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
             <x-offset-m type="double">0</x-offset-m>
             <y-offset-m type="double">-2.3146</y-offset-m>
-            <z-offset-m type="double">10.1192</z-offset-m>
+            <z-offset-m type="double">10.1193</z-offset-m>
             <default-field-of-view-deg type="double">60</default-field-of-view-deg>
         </config>
     </view>
@@ -279,14 +281,32 @@
             <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
             <x-offset-m type="double">3.25</x-offset-m>
             <y-offset-m type="double">2.0382</y-offset-m>
-            <z-offset-m type="double">-6.9016</z-offset-m>
+            <z-offset-m type="double">-8.2443</z-offset-m>
             <heading-offset-deg>-111</heading-offset-deg>
             <pitch-offset-deg>-16.2</pitch-offset-deg>
-            <default-field-of-view-deg type="double">62</default-field-of-view-deg>
+            <default-field-of-view-deg type="double">90</default-field-of-view-deg>
         </config>
     </view>
 
-    <view n="103">
+	<view n="103">
+		<name>Left Aft Wing View</name>
+		<type>lookfrom</type>
+		<internal type="bool">true</internal>
+		<cockpit type="bool">true</cockpit>
+		<config>
+			<from-model type="bool">true</from-model>
+			<from-model-idx type="int">0</from-model-idx>
+			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+			<x-offset-m type="double">0</x-offset-m>
+			<y-offset-m type="double">2.24</y-offset-m>
+			<z-offset-m type="double">7.96</z-offset-m>
+			<pitch-offset-deg>1.6</pitch-offset-deg>
+			<heading-offset-deg>81.5</heading-offset-deg>
+			<default-field-of-view-deg type="double">60</default-field-of-view-deg>
+		</config>
+	</view>
+
+    <view n="104">
         <name>Full Cockpit View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
@@ -297,65 +317,13 @@
             <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
             <x-offset-m type="double">0</x-offset-m>
             <y-offset-m type="double">2.242</y-offset-m>
-            <z-offset-m type="double">-27.642</z-offset-m>
+            <z-offset-m type="double">-28.22</z-offset-m>
             <pitch-offset-deg>-14.5</pitch-offset-deg>
             <default-field-of-view-deg type="double">105</default-field-of-view-deg>
         </config>
     </view>
 
-    <view n="104">
-        <name>EFB View</name>
-        <type>lookfrom</type>
-        <internal type="bool">true</internal>
-        <cockpit type="bool">true</cockpit>
-        <config>
-            <from-model type="bool">true</from-model>
-            <from-model-idx type="int">0</from-model-idx>
-            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-            <x-offset-m type="double">-0.955</x-offset-m>
-            <y-offset-m type="double">1.75</y-offset-m>
-            <z-offset-m type="double">-28.333</z-offset-m>
-            <pitch-offset-deg>-48.6</pitch-offset-deg>
-            <heading-offset-deg>48.6</heading-offset-deg>
-            <default-field-of-view-deg type="double">75</default-field-of-view-deg>
-        </config>
-    </view>
-
     <view n="105">
-        <name>CDU View</name>
-        <type>lookfrom</type>
-        <internal type="bool">true</internal>
-        <cockpit type="bool">true</cockpit>
-        <config>
-            <from-model type="bool">true</from-model>
-            <from-model-idx type="int">0</from-model-idx>
-            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-            <x-offset-m type="double">0</x-offset-m>
-            <y-offset-m type="double">2.4</y-offset-m>
-            <z-offset-m type="double">-28.642</z-offset-m>
-            <pitch-offset-deg>-90</pitch-offset-deg>
-            <default-field-of-view-deg type="double">37</default-field-of-view-deg>
-        </config>
-    </view>
-
-    <view n="106">
-        <name>Overhead Panel View</name>
-        <type>lookfrom</type>
-        <internal type="bool">true</internal>
-        <cockpit type="bool">true</cockpit>
-        <config>
-            <from-model type="bool">true</from-model>
-            <from-model-idx type="int">0</from-model-idx>
-            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-            <x-offset-m type="double">0</x-offset-m>
-            <y-offset-m type="double">1.5</y-offset-m>
-            <z-offset-m type="double">-27.39436</z-offset-m>
-            <pitch-offset-deg>53.1</pitch-offset-deg>
-            <default-field-of-view-deg type="double">70</default-field-of-view-deg>
-        </config>
-    </view>
-
-    <view n="107">
         <name>Copilot View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
@@ -364,7 +332,7 @@
             <from-model type="bool">true</from-model>
             <from-model-idx type="int">0</from-model-idx>
             <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-            <default-field-of-view-deg type="double">60.0</default-field-of-view-deg>
+            <default-field-of-view-deg type="double">90.0</default-field-of-view-deg>
             <default-pitch-deg type="double">0</default-pitch-deg>
             <default-heading-deg type="double">0</default-heading-deg>
             <front-direction-deg type="double">0</front-direction-deg>
@@ -376,13 +344,65 @@
             <right-direction-deg type="double">270</right-direction-deg>
             <front-right-direction-deg type="double">315</front-right-direction-deg>
             <x-offset-m type="double">0.603</x-offset-m>
-            <y-offset-m type="double">2.1135</y-offset-m>
-            <z-offset-m type="double">-27.5427</z-offset-m>
+            <y-offset-m type="double">2.242</y-offset-m>
+            <z-offset-m type="double">-28.872</z-offset-m>
             <pitch-offset-deg>-10.3</pitch-offset-deg>
         </config>
         <dynamic>
             <enabled type="bool" userarchive="y">false</enabled>
         </dynamic>
+    </view>
+
+    <view n="106">
+        <name>EFB View</name>
+        <type>lookfrom</type>
+        <internal type="bool">true</internal>
+        <cockpit type="bool">true</cockpit>
+        <config>
+            <from-model type="bool">true</from-model>
+            <from-model-idx type="int">0</from-model-idx>
+            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+            <x-offset-m type="double">-0.785</x-offset-m>
+            <y-offset-m type="double">2.04</y-offset-m>
+            <z-offset-m type="double">-29.18</z-offset-m>
+            <pitch-offset-deg>-46.6</pitch-offset-deg>
+            <heading-offset-deg>49.275</heading-offset-deg>
+            <default-field-of-view-deg type="double">50</default-field-of-view-deg>
+        </config>
+    </view>
+
+    <view n="107">
+        <name>CDU View</name>
+        <type>lookfrom</type>
+        <internal type="bool">true</internal>
+        <cockpit type="bool">true</cockpit>
+        <config>
+            <from-model type="bool">true</from-model>
+            <from-model-idx type="int">0</from-model-idx>
+            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+            <x-offset-m type="double">0</x-offset-m>
+            <y-offset-m type="double">2.3</y-offset-m>
+            <z-offset-m type="double">-29.34</z-offset-m>
+            <pitch-offset-deg>-73</pitch-offset-deg>
+            <default-field-of-view-deg type="double">41</default-field-of-view-deg>
+        </config>
+    </view>
+
+    <view n="108">
+        <name>Overhead Panel View</name>
+        <type>lookfrom</type>
+        <internal type="bool">true</internal>
+        <cockpit type="bool">true</cockpit>
+        <config>
+            <from-model type="bool">true</from-model>
+            <from-model-idx type="int">0</from-model-idx>
+            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+            <x-offset-m type="double">0</x-offset-m>
+            <y-offset-m type="double">1.8</y-offset-m>
+            <z-offset-m type="double">-28.71</z-offset-m>
+            <pitch-offset-deg>62.9</pitch-offset-deg>
+            <default-field-of-view-deg type="double">78</default-field-of-view-deg>
+        </config>
     </view>
 
         <menubar>

--- a/787-10-GEnx-set.xml
+++ b/787-10-GEnx-set.xml
@@ -353,7 +353,24 @@
         </dynamic>
     </view>
 
-    <view n="106">
+	<view n="106">
+		<name>Center Console View</name>
+		<type>lookfrom</type>
+		<internal type="bool">true</internal>
+		<cockpit type="bool">true</cockpit>
+		<config>
+			<from-model type="bool">true</from-model>
+			<from-model-idx type="int">0</from-model-idx>
+			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+			<x-offset-m type="double">0</x-offset-m>
+			<y-offset-m type="double">1.81</y-offset-m>
+			<z-offset-m type="double">-29.12</z-offset-m>
+			<pitch-offset-deg>-72.2</pitch-offset-deg>
+			<default-field-of-view-deg type="double">90</default-field-of-view-deg>
+		</config>
+	</view>
+
+    <view n="107">
         <name>EFB View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
@@ -371,7 +388,7 @@
         </config>
     </view>
 
-    <view n="107">
+    <view n="108">
         <name>CDU View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
@@ -388,7 +405,7 @@
         </config>
     </view>
 
-    <view n="108">
+    <view n="109">
         <name>Overhead Panel View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>

--- a/787-10-Trent-set.xml
+++ b/787-10-Trent-set.xml
@@ -213,7 +213,7 @@
         <internal type="bool">true</internal>
         <cockpit type="bool">true</cockpit>
         <config>
-            <x-offset-m type="double">-0.603</x-offset-m>
+            <x-offset-m type="double">-0.568</x-offset-m>
             <y-offset-m type="double">2.242</y-offset-m>
             <z-offset-m type="double">-28.872</z-offset-m>
             <pitch-offset-deg>-10.3</pitch-offset-deg>
@@ -343,7 +343,7 @@
             <back-right-direction-deg type="double">225</back-right-direction-deg>
             <right-direction-deg type="double">270</right-direction-deg>
             <front-right-direction-deg type="double">315</front-right-direction-deg>
-            <x-offset-m type="double">0.603</x-offset-m>
+            <x-offset-m type="double">0.568</x-offset-m>
             <y-offset-m type="double">2.242</y-offset-m>
             <z-offset-m type="double">-28.872</z-offset-m>
             <pitch-offset-deg>-10.3</pitch-offset-deg>

--- a/787-10-Trent-set.xml
+++ b/787-10-Trent-set.xml
@@ -206,17 +206,18 @@
             <master-caution type="bool">false</master-caution>
         </alarms>
 
+    <!-- The cockpit is -6.26 z-offset from the cockpit of the 787-8 -->
     <view n="0">
         <name>Pilot View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
         <cockpit type="bool">true</cockpit>
         <config>
-            <x-offset-m type="double">-0.57</x-offset-m>
-            <y-offset-m type="double">2.3</y-offset-m>
-            <z-offset-m type="double">-28.6</z-offset-m>
+            <x-offset-m type="double">-0.603</x-offset-m>
+            <y-offset-m type="double">2.242</y-offset-m>
+            <z-offset-m type="double">-28.872</z-offset-m>
             <pitch-offset-deg>-10.3</pitch-offset-deg>
-            <default-field-of-view-deg type="double">60.0</default-field-of-view-deg>
+            <default-field-of-view-deg type="double">90.0</default-field-of-view-deg>
         </config>
     </view>
 
@@ -252,6 +253,7 @@
             <z-offset-m archive="y" type="double">125.0</z-offset-m>
         </config>
     </view>
+
     <view n="101">
         <name>Gear View</name>
         <type>lookfrom</type>
@@ -263,7 +265,7 @@
             <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
             <x-offset-m type="double">0</x-offset-m>
             <y-offset-m type="double">-2.3146</y-offset-m>
-            <z-offset-m type="double">10.1192</z-offset-m>
+            <z-offset-m type="double">10.1193</z-offset-m>
             <default-field-of-view-deg type="double">60</default-field-of-view-deg>
         </config>
     </view>
@@ -279,14 +281,32 @@
             <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
             <x-offset-m type="double">3.25</x-offset-m>
             <y-offset-m type="double">2.0382</y-offset-m>
-            <z-offset-m type="double">-6.9016</z-offset-m>
+            <z-offset-m type="double">-8.2443</z-offset-m>
             <heading-offset-deg>-111</heading-offset-deg>
             <pitch-offset-deg>-16.2</pitch-offset-deg>
-            <default-field-of-view-deg type="double">62</default-field-of-view-deg>
+            <default-field-of-view-deg type="double">90</default-field-of-view-deg>
         </config>
     </view>
 
-    <view n="103">
+	<view n="103">
+		<name>Left Aft Wing View</name>
+		<type>lookfrom</type>
+		<internal type="bool">true</internal>
+		<cockpit type="bool">true</cockpit>
+		<config>
+			<from-model type="bool">true</from-model>
+			<from-model-idx type="int">0</from-model-idx>
+			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+			<x-offset-m type="double">0</x-offset-m>
+			<y-offset-m type="double">2.24</y-offset-m>
+			<z-offset-m type="double">7.96</z-offset-m>
+			<pitch-offset-deg>1.6</pitch-offset-deg>
+			<heading-offset-deg>81.5</heading-offset-deg>
+			<default-field-of-view-deg type="double">60</default-field-of-view-deg>
+		</config>
+	</view>
+
+    <view n="104">
         <name>Full Cockpit View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
@@ -297,65 +317,13 @@
             <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
             <x-offset-m type="double">0</x-offset-m>
             <y-offset-m type="double">2.242</y-offset-m>
-            <z-offset-m type="double">-27.642</z-offset-m>
+            <z-offset-m type="double">-28.22</z-offset-m>
             <pitch-offset-deg>-14.5</pitch-offset-deg>
             <default-field-of-view-deg type="double">105</default-field-of-view-deg>
         </config>
     </view>
 
-    <view n="104">
-        <name>EFB View</name>
-        <type>lookfrom</type>
-        <internal type="bool">true</internal>
-        <cockpit type="bool">true</cockpit>
-        <config>
-            <from-model type="bool">true</from-model>
-            <from-model-idx type="int">0</from-model-idx>
-            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-            <x-offset-m type="double">-0.955</x-offset-m>
-            <y-offset-m type="double">1.75</y-offset-m>
-            <z-offset-m type="double">-28.333</z-offset-m>
-            <pitch-offset-deg>-48.6</pitch-offset-deg>
-            <heading-offset-deg>48.6</heading-offset-deg>
-            <default-field-of-view-deg type="double">75</default-field-of-view-deg>
-        </config>
-    </view>
-
     <view n="105">
-        <name>CDU View</name>
-        <type>lookfrom</type>
-        <internal type="bool">true</internal>
-        <cockpit type="bool">true</cockpit>
-        <config>
-            <from-model type="bool">true</from-model>
-            <from-model-idx type="int">0</from-model-idx>
-            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-            <x-offset-m type="double">0</x-offset-m>
-            <y-offset-m type="double">2.4</y-offset-m>
-            <z-offset-m type="double">-28.642</z-offset-m>
-            <pitch-offset-deg>-90</pitch-offset-deg>
-            <default-field-of-view-deg type="double">37</default-field-of-view-deg>
-        </config>
-    </view>
-
-    <view n="106">
-        <name>Overhead Panel View</name>
-        <type>lookfrom</type>
-        <internal type="bool">true</internal>
-        <cockpit type="bool">true</cockpit>
-        <config>
-            <from-model type="bool">true</from-model>
-            <from-model-idx type="int">0</from-model-idx>
-            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-            <x-offset-m type="double">0</x-offset-m>
-            <y-offset-m type="double">1.5</y-offset-m>
-            <z-offset-m type="double">-27.39436</z-offset-m>
-            <pitch-offset-deg>53.1</pitch-offset-deg>
-            <default-field-of-view-deg type="double">70</default-field-of-view-deg>
-        </config>
-    </view>
-
-    <view n="107">
         <name>Copilot View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
@@ -364,7 +332,7 @@
             <from-model type="bool">true</from-model>
             <from-model-idx type="int">0</from-model-idx>
             <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-            <default-field-of-view-deg type="double">60.0</default-field-of-view-deg>
+            <default-field-of-view-deg type="double">90.0</default-field-of-view-deg>
             <default-pitch-deg type="double">0</default-pitch-deg>
             <default-heading-deg type="double">0</default-heading-deg>
             <front-direction-deg type="double">0</front-direction-deg>
@@ -376,13 +344,65 @@
             <right-direction-deg type="double">270</right-direction-deg>
             <front-right-direction-deg type="double">315</front-right-direction-deg>
             <x-offset-m type="double">0.603</x-offset-m>
-            <y-offset-m type="double">2.1135</y-offset-m>
-            <z-offset-m type="double">-27.5427</z-offset-m>
+            <y-offset-m type="double">2.242</y-offset-m>
+            <z-offset-m type="double">-28.872</z-offset-m>
             <pitch-offset-deg>-10.3</pitch-offset-deg>
         </config>
         <dynamic>
             <enabled type="bool" userarchive="y">false</enabled>
         </dynamic>
+    </view>
+
+    <view n="106">
+        <name>EFB View</name>
+        <type>lookfrom</type>
+        <internal type="bool">true</internal>
+        <cockpit type="bool">true</cockpit>
+        <config>
+            <from-model type="bool">true</from-model>
+            <from-model-idx type="int">0</from-model-idx>
+            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+            <x-offset-m type="double">-0.785</x-offset-m>
+            <y-offset-m type="double">2.04</y-offset-m>
+            <z-offset-m type="double">-29.18</z-offset-m>
+            <pitch-offset-deg>-46.6</pitch-offset-deg>
+            <heading-offset-deg>49.275</heading-offset-deg>
+            <default-field-of-view-deg type="double">50</default-field-of-view-deg>
+        </config>
+    </view>
+
+    <view n="107">
+        <name>CDU View</name>
+        <type>lookfrom</type>
+        <internal type="bool">true</internal>
+        <cockpit type="bool">true</cockpit>
+        <config>
+            <from-model type="bool">true</from-model>
+            <from-model-idx type="int">0</from-model-idx>
+            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+            <x-offset-m type="double">0</x-offset-m>
+            <y-offset-m type="double">2.3</y-offset-m>
+            <z-offset-m type="double">-29.34</z-offset-m>
+            <pitch-offset-deg>-73</pitch-offset-deg>
+            <default-field-of-view-deg type="double">41</default-field-of-view-deg>
+        </config>
+    </view>
+
+    <view n="108">
+        <name>Overhead Panel View</name>
+        <type>lookfrom</type>
+        <internal type="bool">true</internal>
+        <cockpit type="bool">true</cockpit>
+        <config>
+            <from-model type="bool">true</from-model>
+            <from-model-idx type="int">0</from-model-idx>
+            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+            <x-offset-m type="double">0</x-offset-m>
+            <y-offset-m type="double">1.8</y-offset-m>
+            <z-offset-m type="double">-28.71</z-offset-m>
+            <pitch-offset-deg>62.9</pitch-offset-deg>
+            <default-field-of-view-deg type="double">78</default-field-of-view-deg>
+        </config>
     </view>
 
         <menubar>

--- a/787-10-Trent-set.xml
+++ b/787-10-Trent-set.xml
@@ -353,7 +353,24 @@
         </dynamic>
     </view>
 
-    <view n="106">
+	<view n="106">
+		<name>Center Console View</name>
+		<type>lookfrom</type>
+		<internal type="bool">true</internal>
+		<cockpit type="bool">true</cockpit>
+		<config>
+			<from-model type="bool">true</from-model>
+			<from-model-idx type="int">0</from-model-idx>
+			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+			<x-offset-m type="double">0</x-offset-m>
+			<y-offset-m type="double">1.81</y-offset-m>
+			<z-offset-m type="double">-29.12</z-offset-m>
+			<pitch-offset-deg>-72.2</pitch-offset-deg>
+			<default-field-of-view-deg type="double">90</default-field-of-view-deg>
+		</config>
+	</view>
+
+    <view n="107">
         <name>EFB View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
@@ -371,7 +388,7 @@
         </config>
     </view>
 
-    <view n="107">
+    <view n="108">
         <name>CDU View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
@@ -388,7 +405,7 @@
         </config>
     </view>
 
-    <view n="108">
+    <view n="109">
         <name>Overhead Panel View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>

--- a/787-8-GEnx-set.xml
+++ b/787-8-GEnx-set.xml
@@ -351,6 +351,23 @@
 	</view>
 
 	<view n="106">
+		<name>Center Console View</name>
+		<type>lookfrom</type>
+		<internal type="bool">true</internal>
+		<cockpit type="bool">true</cockpit>
+		<config>
+			<from-model type="bool">true</from-model>
+			<from-model-idx type="int">0</from-model-idx>
+			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+			<x-offset-m type="double">0</x-offset-m>
+			<y-offset-m type="double">1.81</y-offset-m>
+			<z-offset-m type="double">-22.86</z-offset-m>
+			<pitch-offset-deg>-72.2</pitch-offset-deg>
+			<default-field-of-view-deg type="double">90</default-field-of-view-deg>
+		</config>
+	</view>
+
+	<view n="107">
 		<name>EFB View</name>
 		<type>lookfrom</type>
 		<internal type="bool">true</internal>
@@ -368,7 +385,7 @@
 		</config>
 	</view>
 
-	<view n="107">
+	<view n="108">
 		<name>CDU View</name>
 		<type>lookfrom</type>
 		<internal type="bool">true</internal>
@@ -385,7 +402,7 @@
 		</config>
 	</view>
 
-	<view n="108">
+	<view n="109">
 		<name>Overhead Panel View</name>
 		<type>lookfrom</type>
 		<internal type="bool">true</internal>

--- a/787-8-GEnx-set.xml
+++ b/787-8-GEnx-set.xml
@@ -301,6 +301,7 @@
 		</config>
 	</view>
 
+	<!-- TODO: Fix position -->
 	<view n="104">
 		<name>EFB View</name>
 		<type>lookfrom</type>
@@ -319,6 +320,7 @@
 		</config>
 	</view>
 
+	<!-- TODO: Fix position -->
 	<view n="105">
 		<name>CDU View</name>
 		<type>lookfrom</type>
@@ -789,7 +791,6 @@
 	<constant>
 	    <const type="bool">1</const>
 	</constant>
-
 		<engines>
 			<engine-start-switch type="int">1</engine-start-switch>
 			<engine n="0">

--- a/787-8-GEnx-set.xml
+++ b/787-8-GEnx-set.xml
@@ -203,6 +203,7 @@
 			<master-caution type="bool">false</master-caution>
 		</alarms>
 
+	<!-- The cockpit is +3.25 z-offset from the cockpit of the 787-9 -->
 	<view n="0">
 		<name>Pilot View</name>
 		<type>lookfrom</type>
@@ -280,11 +281,29 @@
 			<z-offset-m type="double">-8.2443</z-offset-m>
 			<heading-offset-deg>-111</heading-offset-deg>
 			<pitch-offset-deg>-16.2</pitch-offset-deg>
-			<default-field-of-view-deg type="double">62</default-field-of-view-deg>
+			<default-field-of-view-deg type="double">90</default-field-of-view-deg>
 		</config>
 	</view>
 
 	<view n="103">
+		<name>Left Aft Wing View</name>
+		<type>lookfrom</type>
+		<internal type="bool">true</internal>
+		<cockpit type="bool">true</cockpit>
+		<config>
+			<from-model type="bool">true</from-model>
+			<from-model-idx type="int">0</from-model-idx>
+			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+			<x-offset-m type="double">0</x-offset-m>
+			<y-offset-m type="double">2.24</y-offset-m>
+			<z-offset-m type="double">7.96</z-offset-m>
+			<pitch-offset-deg>1.6</pitch-offset-deg>
+			<heading-offset-deg>81.5</heading-offset-deg>
+			<default-field-of-view-deg type="double">60</default-field-of-view-deg>
+		</config>
+	</view>
+
+	<view n="104">
 		<name>Full Cockpit View</name>
 		<type>lookfrom</type>
 		<internal type="bool">true</internal>
@@ -295,65 +314,13 @@
 			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
 			<x-offset-m type="double">0</x-offset-m>
 			<y-offset-m type="double">2.242</y-offset-m>
-			<z-offset-m type="double">-21.9652</z-offset-m>
+			<z-offset-m type="double">-21.96</z-offset-m>
 			<pitch-offset-deg>-14.5</pitch-offset-deg>
 			<default-field-of-view-deg type="double">105</default-field-of-view-deg>
 		</config>
 	</view>
 
-	<view n="104">
-		<name>EFB View</name>
-		<type>lookfrom</type>
-		<internal type="bool">true</internal>
-		<cockpit type="bool">true</cockpit>
-		<config>
-			<from-model type="bool">true</from-model>
-			<from-model-idx type="int">0</from-model-idx>
-			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-			<x-offset-m type="double">-0.785</x-offset-m>
-			<y-offset-m type="double">2.04</y-offset-m>
-			<z-offset-m type="double">-22.920</z-offset-m>
-			<pitch-offset-deg>-46.6</pitch-offset-deg>
-			<heading-offset-deg>49.275</heading-offset-deg>
-			<default-field-of-view-deg type="double">50</default-field-of-view-deg>
-		</config>
-	</view>
-
 	<view n="105">
-		<name>CDU View</name>
-		<type>lookfrom</type>
-		<internal type="bool">true</internal>
-		<cockpit type="bool">true</cockpit>
-		<config>
-			<from-model type="bool">true</from-model>
-			<from-model-idx type="int">0</from-model-idx>
-			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-			<x-offset-m type="double">0</x-offset-m>
-			<y-offset-m type="double">2.3</y-offset-m>
-			<z-offset-m type="double">-23.081</z-offset-m>
-			<pitch-offset-deg>-73</pitch-offset-deg>
-			<default-field-of-view-deg type="double">41</default-field-of-view-deg>
-		</config>
-	</view>
-
-	<view n="106">
-		<name>Overhead Panel View</name>
-		<type>lookfrom</type>
-		<internal type="bool">true</internal>
-		<cockpit type="bool">true</cockpit>
-		<config>
-			<from-model type="bool">true</from-model>
-			<from-model-idx type="int">0</from-model-idx>
-			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-			<x-offset-m type="double">0</x-offset-m>
-			<y-offset-m type="double">1.8</y-offset-m>
-			<z-offset-m type="double">-22.45167</z-offset-m>
-			<pitch-offset-deg>62.9</pitch-offset-deg>
-			<default-field-of-view-deg type="double">78</default-field-of-view-deg>
-		</config>
-	</view>
-
-	<view n="107">
 		<name>Copilot View</name>
 		<type>lookfrom</type>
 		<internal type="bool">true</internal>
@@ -362,7 +329,7 @@
 			<from-model type="bool">true</from-model>
 			<from-model-idx type="int">0</from-model-idx>
 			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-			<default-field-of-view-deg type="double">60.0</default-field-of-view-deg>
+			<default-field-of-view-deg type="double">90.0</default-field-of-view-deg>
 			<default-pitch-deg type="double">0</default-pitch-deg>
 			<default-heading-deg type="double">0</default-heading-deg>
 			<front-direction-deg type="double">0</front-direction-deg>
@@ -382,8 +349,27 @@
 			<enabled type="bool" userarchive="y">false</enabled>
 		</dynamic>
 	</view>
-	<view n="108">
-		<name>Left Aft Wing View</name>
+
+	<view n="106">
+		<name>EFB View</name>
+		<type>lookfrom</type>
+		<internal type="bool">true</internal>
+		<cockpit type="bool">true</cockpit>
+		<config>
+			<from-model type="bool">true</from-model>
+			<from-model-idx type="int">0</from-model-idx>
+			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+			<x-offset-m type="double">-0.785</x-offset-m>
+			<y-offset-m type="double">2.04</y-offset-m>
+			<z-offset-m type="double">-22.920</z-offset-m>
+			<pitch-offset-deg>-46.6</pitch-offset-deg>
+			<heading-offset-deg>49.275</heading-offset-deg>
+			<default-field-of-view-deg type="double">50</default-field-of-view-deg>
+		</config>
+	</view>
+
+	<view n="107">
+		<name>CDU View</name>
 		<type>lookfrom</type>
 		<internal type="bool">true</internal>
 		<cockpit type="bool">true</cockpit>
@@ -392,11 +378,27 @@
 			<from-model-idx type="int">0</from-model-idx>
 			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
 			<x-offset-m type="double">0</x-offset-m>
-			<y-offset-m type="double">2.24</y-offset-m>
-			<z-offset-m type="double">7.96</z-offset-m>
-			<pitch-offset-deg>1.6</pitch-offset-deg>
-			<heading-offset-deg>81.5</heading-offset-deg>
-			<default-field-of-view-deg type="double">60</default-field-of-view-deg>
+			<y-offset-m type="double">2.3</y-offset-m>
+			<z-offset-m type="double">-23.08</z-offset-m>
+			<pitch-offset-deg>-73</pitch-offset-deg>
+			<default-field-of-view-deg type="double">41</default-field-of-view-deg>
+		</config>
+	</view>
+
+	<view n="108">
+		<name>Overhead Panel View</name>
+		<type>lookfrom</type>
+		<internal type="bool">true</internal>
+		<cockpit type="bool">true</cockpit>
+		<config>
+			<from-model type="bool">true</from-model>
+			<from-model-idx type="int">0</from-model-idx>
+			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+			<x-offset-m type="double">0</x-offset-m>
+			<y-offset-m type="double">1.8</y-offset-m>
+			<z-offset-m type="double">-22.45</z-offset-m>
+			<pitch-offset-deg>62.9</pitch-offset-deg>
+			<default-field-of-view-deg type="double">78</default-field-of-view-deg>
 		</config>
 	</view>
 

--- a/787-8-GEnx-set.xml
+++ b/787-8-GEnx-set.xml
@@ -210,7 +210,7 @@
 		<internal type="bool">true</internal>
 		<cockpit type="bool">true</cockpit>
 		<config>
-			<x-offset-m type="double">-0.603</x-offset-m>
+			<x-offset-m type="double">-0.568</x-offset-m>
 			<y-offset-m type="double">2.242</y-offset-m>
 			<z-offset-m type="double">-22.612</z-offset-m>
 			<pitch-offset-deg>-10.3</pitch-offset-deg>
@@ -340,7 +340,7 @@
 			<back-right-direction-deg type="double">225</back-right-direction-deg>
 			<right-direction-deg type="double">270</right-direction-deg>
 			<front-right-direction-deg type="double">315</front-right-direction-deg>
-			<x-offset-m type="double">0.603</x-offset-m>
+			<x-offset-m type="double">0.568</x-offset-m>
 			<y-offset-m type="double">2.242</y-offset-m>
 			<z-offset-m type="double">-22.612</z-offset-m>
 			<pitch-offset-deg>-10.3</pitch-offset-deg>

--- a/787-8-GEnx-set.xml
+++ b/787-8-GEnx-set.xml
@@ -213,7 +213,7 @@
 			<y-offset-m type="double">2.242</y-offset-m>
 			<z-offset-m type="double">-22.612</z-offset-m>
 			<pitch-offset-deg>-10.3</pitch-offset-deg>
-			<default-field-of-view-deg type="double">60.0</default-field-of-view-deg>
+			<default-field-of-view-deg type="double">90.0</default-field-of-view-deg>
 		</config>
 	</view>
 
@@ -301,7 +301,6 @@
 		</config>
 	</view>
 
-	<!-- TODO: Fix position -->
 	<view n="104">
 		<name>EFB View</name>
 		<type>lookfrom</type>
@@ -311,16 +310,15 @@
 			<from-model type="bool">true</from-model>
 			<from-model-idx type="int">0</from-model-idx>
 			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-			<x-offset-m type="double">-0.955</x-offset-m>
-			<y-offset-m type="double">1.8</y-offset-m>
-			<z-offset-m type="double">-23.2902</z-offset-m>
-			<pitch-offset-deg>-48.6</pitch-offset-deg>
-			<heading-offset-deg>48.6</heading-offset-deg>
-			<default-field-of-view-deg type="double">45.9</default-field-of-view-deg>
+			<x-offset-m type="double">-0.785</x-offset-m>
+			<y-offset-m type="double">2.04</y-offset-m>
+			<z-offset-m type="double">-22.920</z-offset-m>
+			<pitch-offset-deg>-46.6</pitch-offset-deg>
+			<heading-offset-deg>49.275</heading-offset-deg>
+			<default-field-of-view-deg type="double">50</default-field-of-view-deg>
 		</config>
 	</view>
 
-	<!-- TODO: Fix position -->
 	<view n="105">
 		<name>CDU View</name>
 		<type>lookfrom</type>
@@ -331,10 +329,10 @@
 			<from-model-idx type="int">0</from-model-idx>
 			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
 			<x-offset-m type="double">0</x-offset-m>
-			<y-offset-m type="double">2.2</y-offset-m>
-			<z-offset-m type="double">-22.95167</z-offset-m>
-			<pitch-offset-deg>-90</pitch-offset-deg>
-			<default-field-of-view-deg type="double">18</default-field-of-view-deg>
+			<y-offset-m type="double">2.3</y-offset-m>
+			<z-offset-m type="double">-23.081</z-offset-m>
+			<pitch-offset-deg>-73</pitch-offset-deg>
+			<default-field-of-view-deg type="double">41</default-field-of-view-deg>
 		</config>
 	</view>
 
@@ -350,8 +348,8 @@
 			<x-offset-m type="double">0</x-offset-m>
 			<y-offset-m type="double">1.8</y-offset-m>
 			<z-offset-m type="double">-22.45167</z-offset-m>
-			<pitch-offset-deg>53.1</pitch-offset-deg>
-			<default-field-of-view-deg type="double">70</default-field-of-view-deg>
+			<pitch-offset-deg>62.9</pitch-offset-deg>
+			<default-field-of-view-deg type="double">78</default-field-of-view-deg>
 		</config>
 	</view>
 

--- a/787-8-Trent-set.xml
+++ b/787-8-Trent-set.xml
@@ -351,6 +351,23 @@
 	</view>
 
 	<view n="106">
+		<name>Center Console View</name>
+		<type>lookfrom</type>
+		<internal type="bool">true</internal>
+		<cockpit type="bool">true</cockpit>
+		<config>
+			<from-model type="bool">true</from-model>
+			<from-model-idx type="int">0</from-model-idx>
+			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+			<x-offset-m type="double">0</x-offset-m>
+			<y-offset-m type="double">1.81</y-offset-m>
+			<z-offset-m type="double">-22.86</z-offset-m>
+			<pitch-offset-deg>-72.2</pitch-offset-deg>
+			<default-field-of-view-deg type="double">90</default-field-of-view-deg>
+		</config>
+	</view>
+
+	<view n="107">
 		<name>EFB View</name>
 		<type>lookfrom</type>
 		<internal type="bool">true</internal>
@@ -368,7 +385,7 @@
 		</config>
 	</view>
 
-	<view n="107">
+	<view n="108">
 		<name>CDU View</name>
 		<type>lookfrom</type>
 		<internal type="bool">true</internal>
@@ -385,7 +402,7 @@
 		</config>
 	</view>
 
-	<view n="108">
+	<view n="109">
 		<name>Overhead Panel View</name>
 		<type>lookfrom</type>
 		<internal type="bool">true</internal>

--- a/787-8-Trent-set.xml
+++ b/787-8-Trent-set.xml
@@ -203,6 +203,7 @@
 			<master-caution type="bool">false</master-caution>
 		</alarms>
 
+	<!-- The cockpit is +3.25 z-offset from the cockpit of the 787-9 -->
 	<view n="0">
 		<name>Pilot View</name>
 		<type>lookfrom</type>
@@ -280,11 +281,29 @@
 			<z-offset-m type="double">-8.2443</z-offset-m>
 			<heading-offset-deg>-111</heading-offset-deg>
 			<pitch-offset-deg>-16.2</pitch-offset-deg>
-			<default-field-of-view-deg type="double">62</default-field-of-view-deg>
+			<default-field-of-view-deg type="double">90</default-field-of-view-deg>
 		</config>
 	</view>
 
 	<view n="103">
+		<name>Left Aft Wing View</name>
+		<type>lookfrom</type>
+		<internal type="bool">true</internal>
+		<cockpit type="bool">true</cockpit>
+		<config>
+			<from-model type="bool">true</from-model>
+			<from-model-idx type="int">0</from-model-idx>
+			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+			<x-offset-m type="double">0</x-offset-m>
+			<y-offset-m type="double">2.24</y-offset-m>
+			<z-offset-m type="double">7.96</z-offset-m>
+			<pitch-offset-deg>1.6</pitch-offset-deg>
+			<heading-offset-deg>81.5</heading-offset-deg>
+			<default-field-of-view-deg type="double">60</default-field-of-view-deg>
+		</config>
+	</view>
+
+	<view n="104">
 		<name>Full Cockpit View</name>
 		<type>lookfrom</type>
 		<internal type="bool">true</internal>
@@ -295,65 +314,13 @@
 			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
 			<x-offset-m type="double">0</x-offset-m>
 			<y-offset-m type="double">2.242</y-offset-m>
-			<z-offset-m type="double">-21.9652</z-offset-m>
+			<z-offset-m type="double">-21.96</z-offset-m>
 			<pitch-offset-deg>-14.5</pitch-offset-deg>
 			<default-field-of-view-deg type="double">105</default-field-of-view-deg>
 		</config>
 	</view>
 
-	<view n="104">
-		<name>EFB View</name>
-		<type>lookfrom</type>
-		<internal type="bool">true</internal>
-		<cockpit type="bool">true</cockpit>
-		<config>
-			<from-model type="bool">true</from-model>
-			<from-model-idx type="int">0</from-model-idx>
-			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-			<x-offset-m type="double">-0.785</x-offset-m>
-			<y-offset-m type="double">2.04</y-offset-m>
-			<z-offset-m type="double">-22.920</z-offset-m>
-			<pitch-offset-deg>-46.6</pitch-offset-deg>
-			<heading-offset-deg>49.275</heading-offset-deg>
-			<default-field-of-view-deg type="double">50</default-field-of-view-deg>
-		</config>
-	</view>
-
 	<view n="105">
-		<name>CDU View</name>
-		<type>lookfrom</type>
-		<internal type="bool">true</internal>
-		<cockpit type="bool">true</cockpit>
-		<config>
-			<from-model type="bool">true</from-model>
-			<from-model-idx type="int">0</from-model-idx>
-			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-			<x-offset-m type="double">0</x-offset-m>
-			<y-offset-m type="double">2.3</y-offset-m>
-			<z-offset-m type="double">-23.081</z-offset-m>
-			<pitch-offset-deg>-73</pitch-offset-deg>
-			<default-field-of-view-deg type="double">41</default-field-of-view-deg>
-		</config>
-	</view>
-
-	<view n="106">
-		<name>Overhead Panel View</name>
-		<type>lookfrom</type>
-		<internal type="bool">true</internal>
-		<cockpit type="bool">true</cockpit>
-		<config>
-			<from-model type="bool">true</from-model>
-			<from-model-idx type="int">0</from-model-idx>
-			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-			<x-offset-m type="double">0</x-offset-m>
-			<y-offset-m type="double">1.8</y-offset-m>
-			<z-offset-m type="double">-22.45167</z-offset-m>
-			<pitch-offset-deg>62.9</pitch-offset-deg>
-			<default-field-of-view-deg type="double">78</default-field-of-view-deg>
-		</config>
-	</view>
-
-	<view n="107">
 		<name>Copilot View</name>
 		<type>lookfrom</type>
 		<internal type="bool">true</internal>
@@ -362,7 +329,7 @@
 			<from-model type="bool">true</from-model>
 			<from-model-idx type="int">0</from-model-idx>
 			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-			<default-field-of-view-deg type="double">60.0</default-field-of-view-deg>
+			<default-field-of-view-deg type="double">90.0</default-field-of-view-deg>
 			<default-pitch-deg type="double">0</default-pitch-deg>
 			<default-heading-deg type="double">0</default-heading-deg>
 			<front-direction-deg type="double">0</front-direction-deg>
@@ -382,8 +349,27 @@
 			<enabled type="bool" userarchive="y">false</enabled>
 		</dynamic>
 	</view>
-	<view n="108">
-		<name>Left Aft Wing View</name>
+
+	<view n="106">
+		<name>EFB View</name>
+		<type>lookfrom</type>
+		<internal type="bool">true</internal>
+		<cockpit type="bool">true</cockpit>
+		<config>
+			<from-model type="bool">true</from-model>
+			<from-model-idx type="int">0</from-model-idx>
+			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+			<x-offset-m type="double">-0.785</x-offset-m>
+			<y-offset-m type="double">2.04</y-offset-m>
+			<z-offset-m type="double">-22.920</z-offset-m>
+			<pitch-offset-deg>-46.6</pitch-offset-deg>
+			<heading-offset-deg>49.275</heading-offset-deg>
+			<default-field-of-view-deg type="double">50</default-field-of-view-deg>
+		</config>
+	</view>
+
+	<view n="107">
+		<name>CDU View</name>
 		<type>lookfrom</type>
 		<internal type="bool">true</internal>
 		<cockpit type="bool">true</cockpit>
@@ -392,11 +378,27 @@
 			<from-model-idx type="int">0</from-model-idx>
 			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
 			<x-offset-m type="double">0</x-offset-m>
-			<y-offset-m type="double">2.24</y-offset-m>
-			<z-offset-m type="double">7.96</z-offset-m>
-			<pitch-offset-deg>1.6</pitch-offset-deg>
-			<heading-offset-deg>81.5</heading-offset-deg>
-			<default-field-of-view-deg type="double">60</default-field-of-view-deg>
+			<y-offset-m type="double">2.3</y-offset-m>
+			<z-offset-m type="double">-23.08</z-offset-m>
+			<pitch-offset-deg>-73</pitch-offset-deg>
+			<default-field-of-view-deg type="double">41</default-field-of-view-deg>
+		</config>
+	</view>
+
+	<view n="108">
+		<name>Overhead Panel View</name>
+		<type>lookfrom</type>
+		<internal type="bool">true</internal>
+		<cockpit type="bool">true</cockpit>
+		<config>
+			<from-model type="bool">true</from-model>
+			<from-model-idx type="int">0</from-model-idx>
+			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+			<x-offset-m type="double">0</x-offset-m>
+			<y-offset-m type="double">1.8</y-offset-m>
+			<z-offset-m type="double">-22.45</z-offset-m>
+			<pitch-offset-deg>62.9</pitch-offset-deg>
+			<default-field-of-view-deg type="double">78</default-field-of-view-deg>
 		</config>
 	</view>
 

--- a/787-8-Trent-set.xml
+++ b/787-8-Trent-set.xml
@@ -301,6 +301,7 @@
 		</config>
 	</view>
 
+	<!-- TODO: Fix position -->
 	<view n="104">
 		<name>EFB View</name>
 		<type>lookfrom</type>
@@ -319,6 +320,7 @@
 		</config>
 	</view>
 
+	<!-- TODO: Fix position -->
 	<view n="105">
 		<name>CDU View</name>
 		<type>lookfrom</type>

--- a/787-8-Trent-set.xml
+++ b/787-8-Trent-set.xml
@@ -210,7 +210,7 @@
 		<internal type="bool">true</internal>
 		<cockpit type="bool">true</cockpit>
 		<config>
-			<x-offset-m type="double">-0.603</x-offset-m>
+			<x-offset-m type="double">-0.568</x-offset-m>
 			<y-offset-m type="double">2.242</y-offset-m>
 			<z-offset-m type="double">-22.612</z-offset-m>
 			<pitch-offset-deg>-10.3</pitch-offset-deg>
@@ -340,7 +340,7 @@
 			<back-right-direction-deg type="double">225</back-right-direction-deg>
 			<right-direction-deg type="double">270</right-direction-deg>
 			<front-right-direction-deg type="double">315</front-right-direction-deg>
-			<x-offset-m type="double">0.603</x-offset-m>
+			<x-offset-m type="double">0.568</x-offset-m>
 			<y-offset-m type="double">2.242</y-offset-m>
 			<z-offset-m type="double">-22.612</z-offset-m>
 			<pitch-offset-deg>-10.3</pitch-offset-deg>

--- a/787-8-Trent-set.xml
+++ b/787-8-Trent-set.xml
@@ -213,7 +213,7 @@
 			<y-offset-m type="double">2.242</y-offset-m>
 			<z-offset-m type="double">-22.612</z-offset-m>
 			<pitch-offset-deg>-10.3</pitch-offset-deg>
-			<default-field-of-view-deg type="double">60.0</default-field-of-view-deg>
+			<default-field-of-view-deg type="double">90.0</default-field-of-view-deg>
 		</config>
 	</view>
 
@@ -301,7 +301,6 @@
 		</config>
 	</view>
 
-	<!-- TODO: Fix position -->
 	<view n="104">
 		<name>EFB View</name>
 		<type>lookfrom</type>
@@ -311,16 +310,15 @@
 			<from-model type="bool">true</from-model>
 			<from-model-idx type="int">0</from-model-idx>
 			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-			<x-offset-m type="double">-0.955</x-offset-m>
-			<y-offset-m type="double">1.8</y-offset-m>
-			<z-offset-m type="double">-23.2902</z-offset-m>
-			<pitch-offset-deg>-48.6</pitch-offset-deg>
-			<heading-offset-deg>48.6</heading-offset-deg>
-			<default-field-of-view-deg type="double">45.9</default-field-of-view-deg>
+			<x-offset-m type="double">-0.785</x-offset-m>
+			<y-offset-m type="double">2.04</y-offset-m>
+			<z-offset-m type="double">-22.920</z-offset-m>
+			<pitch-offset-deg>-46.6</pitch-offset-deg>
+			<heading-offset-deg>49.275</heading-offset-deg>
+			<default-field-of-view-deg type="double">50</default-field-of-view-deg>
 		</config>
 	</view>
 
-	<!-- TODO: Fix position -->
 	<view n="105">
 		<name>CDU View</name>
 		<type>lookfrom</type>
@@ -331,10 +329,10 @@
 			<from-model-idx type="int">0</from-model-idx>
 			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
 			<x-offset-m type="double">0</x-offset-m>
-			<y-offset-m type="double">2.2</y-offset-m>
-			<z-offset-m type="double">-22.95167</z-offset-m>
-			<pitch-offset-deg>-90</pitch-offset-deg>
-			<default-field-of-view-deg type="double">18</default-field-of-view-deg>
+			<y-offset-m type="double">2.3</y-offset-m>
+			<z-offset-m type="double">-23.081</z-offset-m>
+			<pitch-offset-deg>-73</pitch-offset-deg>
+			<default-field-of-view-deg type="double">41</default-field-of-view-deg>
 		</config>
 	</view>
 
@@ -350,8 +348,8 @@
 			<x-offset-m type="double">0</x-offset-m>
 			<y-offset-m type="double">1.8</y-offset-m>
 			<z-offset-m type="double">-22.45167</z-offset-m>
-			<pitch-offset-deg>53.1</pitch-offset-deg>
-			<default-field-of-view-deg type="double">70</default-field-of-view-deg>
+			<pitch-offset-deg>62.9</pitch-offset-deg>
+			<default-field-of-view-deg type="double">78</default-field-of-view-deg>
 		</config>
 	</view>
 

--- a/787-9-GEnx-set.xml
+++ b/787-9-GEnx-set.xml
@@ -213,7 +213,7 @@
         <internal type="bool">true</internal>
         <cockpit type="bool">true</cockpit>
         <config>
-            <x-offset-m type="double">-0.603</x-offset-m>
+            <x-offset-m type="double">-0.568</x-offset-m>
             <y-offset-m type="double">2.242</y-offset-m>
             <z-offset-m type="double">-25.86</z-offset-m>
             <pitch-offset-deg>-10.3</pitch-offset-deg>
@@ -343,7 +343,7 @@
             <back-right-direction-deg type="double">225</back-right-direction-deg>
             <right-direction-deg type="double">270</right-direction-deg>
             <front-right-direction-deg type="double">315</front-right-direction-deg>
-            <x-offset-m type="double">0.603</x-offset-m>
+            <x-offset-m type="double">0.568</x-offset-m>
             <y-offset-m type="double">2.242</y-offset-m>
             <z-offset-m type="double">-25.862</z-offset-m>
             <pitch-offset-deg>-10.3</pitch-offset-deg>

--- a/787-9-GEnx-set.xml
+++ b/787-9-GEnx-set.xml
@@ -206,6 +206,7 @@
             <master-caution type="bool">false</master-caution>
         </alarms>
 
+    <!-- The cockpit is -3.25 z-offset from the cockpit of the 787-8 -->
     <view n="0">
         <name>Pilot View</name>
         <type>lookfrom</type>
@@ -213,10 +214,10 @@
         <cockpit type="bool">true</cockpit>
         <config>
             <x-offset-m type="double">-0.603</x-offset-m>
-            <y-offset-m type="double">2.11</y-offset-m>
-            <z-offset-m type="double">-26.20</z-offset-m>
+            <y-offset-m type="double">2.242</y-offset-m>
+            <z-offset-m type="double">-25.86</z-offset-m>
             <pitch-offset-deg>-10.3</pitch-offset-deg>
-            <default-field-of-view-deg type="double">60.0</default-field-of-view-deg>
+            <default-field-of-view-deg type="double">90.0</default-field-of-view-deg>
         </config>
     </view>
 
@@ -252,6 +253,7 @@
             <z-offset-m archive="y" type="double">125.0</z-offset-m>
         </config>
     </view>
+
     <view n="101">
         <name>Gear View</name>
         <type>lookfrom</type>
@@ -263,7 +265,7 @@
             <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
             <x-offset-m type="double">0</x-offset-m>
             <y-offset-m type="double">-2.3146</y-offset-m>
-            <z-offset-m type="double">10.1192</z-offset-m>
+            <z-offset-m type="double">10.1193</z-offset-m>
             <default-field-of-view-deg type="double">60</default-field-of-view-deg>
         </config>
     </view>
@@ -282,11 +284,29 @@
             <z-offset-m type="double">-8.2443</z-offset-m>
             <heading-offset-deg>-111</heading-offset-deg>
             <pitch-offset-deg>-16.2</pitch-offset-deg>
-            <default-field-of-view-deg type="double">62</default-field-of-view-deg>
+            <default-field-of-view-deg type="double">90</default-field-of-view-deg>
         </config>
     </view>
 
-    <view n="103">
+	<view n="103">
+		<name>Left Aft Wing View</name>
+		<type>lookfrom</type>
+		<internal type="bool">true</internal>
+		<cockpit type="bool">true</cockpit>
+		<config>
+			<from-model type="bool">true</from-model>
+			<from-model-idx type="int">0</from-model-idx>
+			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+			<x-offset-m type="double">0</x-offset-m>
+			<y-offset-m type="double">2.24</y-offset-m>
+			<z-offset-m type="double">7.96</z-offset-m>
+			<pitch-offset-deg>1.6</pitch-offset-deg>
+			<heading-offset-deg>81.5</heading-offset-deg>
+			<default-field-of-view-deg type="double">60</default-field-of-view-deg>
+		</config>
+	</view>
+
+    <view n="104">
         <name>Full Cockpit View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
@@ -297,65 +317,13 @@
             <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
             <x-offset-m type="double">0</x-offset-m>
             <y-offset-m type="double">2.242</y-offset-m>
-            <z-offset-m type="double">-26.3</z-offset-m>
+            <z-offset-m type="double">-25.21</z-offset-m>
             <pitch-offset-deg>-14.5</pitch-offset-deg>
             <default-field-of-view-deg type="double">105</default-field-of-view-deg>
         </config>
     </view>
 
-    <view n="104">
-        <name>EFB View</name>
-        <type>lookfrom</type>
-        <internal type="bool">true</internal>
-        <cockpit type="bool">true</cockpit>
-        <config>
-            <from-model type="bool">true</from-model>
-            <from-model-idx type="int">0</from-model-idx>
-            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-            <x-offset-m type="double">-0.955</x-offset-m>
-            <y-offset-m type="double">1.75</y-offset-m>
-            <z-offset-m type="double">-26.9902</z-offset-m>
-            <pitch-offset-deg>-48.6</pitch-offset-deg>
-            <heading-offset-deg>48.6</heading-offset-deg>
-            <default-field-of-view-deg type="double">75</default-field-of-view-deg>
-        </config>
-    </view>
-
     <view n="105">
-        <name>CDU View</name>
-        <type>lookfrom</type>
-        <internal type="bool">true</internal>
-        <cockpit type="bool">true</cockpit>
-        <config>
-            <from-model type="bool">true</from-model>
-            <from-model-idx type="int">0</from-model-idx>
-            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-            <x-offset-m type="double">0</x-offset-m>
-            <y-offset-m type="double">2.4</y-offset-m>
-            <z-offset-m type="double">-27.3</z-offset-m>
-            <pitch-offset-deg>-90</pitch-offset-deg>
-            <default-field-of-view-deg type="double">37</default-field-of-view-deg>
-        </config>
-    </view>
-
-    <view n="106">
-        <name>Overhead Panel View</name>
-        <type>lookfrom</type>
-        <internal type="bool">true</internal>
-        <cockpit type="bool">true</cockpit>
-        <config>
-            <from-model type="bool">true</from-model>
-            <from-model-idx type="int">0</from-model-idx>
-            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-            <x-offset-m type="double">0</x-offset-m>
-            <y-offset-m type="double">1.5</y-offset-m>
-            <z-offset-m type="double">26.0517</z-offset-m>
-            <pitch-offset-deg>53.1</pitch-offset-deg>
-            <default-field-of-view-deg type="double">70</default-field-of-view-deg>
-        </config>
-    </view>
-
-    <view n="107">
         <name>Copilot View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
@@ -364,7 +332,7 @@
             <from-model type="bool">true</from-model>
             <from-model-idx type="int">0</from-model-idx>
             <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-            <default-field-of-view-deg type="double">60.0</default-field-of-view-deg>
+            <default-field-of-view-deg type="double">90.0</default-field-of-view-deg>
             <default-pitch-deg type="double">0</default-pitch-deg>
             <default-heading-deg type="double">0</default-heading-deg>
             <front-direction-deg type="double">0</front-direction-deg>
@@ -376,13 +344,65 @@
             <right-direction-deg type="double">270</right-direction-deg>
             <front-right-direction-deg type="double">315</front-right-direction-deg>
             <x-offset-m type="double">0.603</x-offset-m>
-            <y-offset-m type="double">2.08</y-offset-m>
-            <z-offset-m type="double">-26.2</z-offset-m>
+            <y-offset-m type="double">2.242</y-offset-m>
+            <z-offset-m type="double">-25.862</z-offset-m>
             <pitch-offset-deg>-10.3</pitch-offset-deg>
         </config>
         <dynamic>
             <enabled type="bool" userarchive="y">false</enabled>
         </dynamic>
+    </view>
+
+    <view n="106">
+        <name>EFB View</name>
+        <type>lookfrom</type>
+        <internal type="bool">true</internal>
+        <cockpit type="bool">true</cockpit>
+        <config>
+            <from-model type="bool">true</from-model>
+            <from-model-idx type="int">0</from-model-idx>
+            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+            <x-offset-m type="double">-0.785</x-offset-m>
+            <y-offset-m type="double">2.04</y-offset-m>
+            <z-offset-m type="double">-26.16</z-offset-m>
+            <pitch-offset-deg>-46.6</pitch-offset-deg>
+            <heading-offset-deg>49.275</heading-offset-deg>
+            <default-field-of-view-deg type="double">50</default-field-of-view-deg>
+        </config>
+    </view>
+
+    <view n="107">
+        <name>CDU View</name>
+        <type>lookfrom</type>
+        <internal type="bool">true</internal>
+        <cockpit type="bool">true</cockpit>
+        <config>
+            <from-model type="bool">true</from-model>
+            <from-model-idx type="int">0</from-model-idx>
+            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+            <x-offset-m type="double">0</x-offset-m>
+            <y-offset-m type="double">2.3</y-offset-m>
+            <z-offset-m type="double">-26.33</z-offset-m>
+            <pitch-offset-deg>-73</pitch-offset-deg>
+            <default-field-of-view-deg type="double">41</default-field-of-view-deg>
+        </config>
+    </view>
+
+    <view n="108">
+        <name>Overhead Panel View</name>
+        <type>lookfrom</type>
+        <internal type="bool">true</internal>
+        <cockpit type="bool">true</cockpit>
+        <config>
+            <from-model type="bool">true</from-model>
+            <from-model-idx type="int">0</from-model-idx>
+            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+            <x-offset-m type="double">0</x-offset-m>
+            <y-offset-m type="double">1.8</y-offset-m>
+            <z-offset-m type="double">-25.7</z-offset-m>
+            <pitch-offset-deg>62.9</pitch-offset-deg>
+            <default-field-of-view-deg type="double">78</default-field-of-view-deg>
+        </config>
     </view>
 
         <menubar>

--- a/787-9-GEnx-set.xml
+++ b/787-9-GEnx-set.xml
@@ -353,7 +353,24 @@
         </dynamic>
     </view>
 
-    <view n="106">
+	<view n="106">
+		<name>Center Console View</name>
+		<type>lookfrom</type>
+		<internal type="bool">true</internal>
+		<cockpit type="bool">true</cockpit>
+		<config>
+			<from-model type="bool">true</from-model>
+			<from-model-idx type="int">0</from-model-idx>
+			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+			<x-offset-m type="double">0</x-offset-m>
+			<y-offset-m type="double">1.81</y-offset-m>
+			<z-offset-m type="double">-26.11</z-offset-m>
+			<pitch-offset-deg>-72.2</pitch-offset-deg>
+			<default-field-of-view-deg type="double">90</default-field-of-view-deg>
+		</config>
+	</view>
+
+    <view n="107">
         <name>EFB View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
@@ -371,7 +388,7 @@
         </config>
     </view>
 
-    <view n="107">
+    <view n="108">
         <name>CDU View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
@@ -388,7 +405,7 @@
         </config>
     </view>
 
-    <view n="108">
+    <view n="109">
         <name>Overhead Panel View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>

--- a/787-9-Trent-set.xml
+++ b/787-9-Trent-set.xml
@@ -213,7 +213,7 @@
         <internal type="bool">true</internal>
         <cockpit type="bool">true</cockpit>
         <config>
-            <x-offset-m type="double">-0.603</x-offset-m>
+            <x-offset-m type="double">-0.568</x-offset-m>
             <y-offset-m type="double">2.242</y-offset-m>
             <z-offset-m type="double">-25.86</z-offset-m>
             <pitch-offset-deg>-10.3</pitch-offset-deg>
@@ -343,7 +343,7 @@
             <back-right-direction-deg type="double">225</back-right-direction-deg>
             <right-direction-deg type="double">270</right-direction-deg>
             <front-right-direction-deg type="double">315</front-right-direction-deg>
-            <x-offset-m type="double">0.603</x-offset-m>
+            <x-offset-m type="double">0.568</x-offset-m>
             <y-offset-m type="double">2.242</y-offset-m>
             <z-offset-m type="double">-25.862</z-offset-m>
             <pitch-offset-deg>-10.3</pitch-offset-deg>

--- a/787-9-Trent-set.xml
+++ b/787-9-Trent-set.xml
@@ -206,6 +206,7 @@
             <master-caution type="bool">false</master-caution>
         </alarms>
 
+    <!-- The cockpit is -3.25 z-offset from the cockpit of the 787-8 -->
     <view n="0">
         <name>Pilot View</name>
         <type>lookfrom</type>
@@ -213,10 +214,10 @@
         <cockpit type="bool">true</cockpit>
         <config>
             <x-offset-m type="double">-0.603</x-offset-m>
-            <y-offset-m type="double">2.11</y-offset-m>
-            <z-offset-m type="double">-26.20</z-offset-m>
+            <y-offset-m type="double">2.242</y-offset-m>
+            <z-offset-m type="double">-25.86</z-offset-m>
             <pitch-offset-deg>-10.3</pitch-offset-deg>
-            <default-field-of-view-deg type="double">60.0</default-field-of-view-deg>
+            <default-field-of-view-deg type="double">90.0</default-field-of-view-deg>
         </config>
     </view>
 
@@ -252,6 +253,7 @@
             <z-offset-m archive="y" type="double">125.0</z-offset-m>
         </config>
     </view>
+
     <view n="101">
         <name>Gear View</name>
         <type>lookfrom</type>
@@ -263,7 +265,7 @@
             <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
             <x-offset-m type="double">0</x-offset-m>
             <y-offset-m type="double">-2.3146</y-offset-m>
-            <z-offset-m type="double">10.1192</z-offset-m>
+            <z-offset-m type="double">10.1193</z-offset-m>
             <default-field-of-view-deg type="double">60</default-field-of-view-deg>
         </config>
     </view>
@@ -282,11 +284,29 @@
             <z-offset-m type="double">-8.2443</z-offset-m>
             <heading-offset-deg>-111</heading-offset-deg>
             <pitch-offset-deg>-16.2</pitch-offset-deg>
-            <default-field-of-view-deg type="double">62</default-field-of-view-deg>
+            <default-field-of-view-deg type="double">90</default-field-of-view-deg>
         </config>
     </view>
 
-    <view n="103">
+	<view n="103">
+		<name>Left Aft Wing View</name>
+		<type>lookfrom</type>
+		<internal type="bool">true</internal>
+		<cockpit type="bool">true</cockpit>
+		<config>
+			<from-model type="bool">true</from-model>
+			<from-model-idx type="int">0</from-model-idx>
+			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+			<x-offset-m type="double">0</x-offset-m>
+			<y-offset-m type="double">2.24</y-offset-m>
+			<z-offset-m type="double">7.96</z-offset-m>
+			<pitch-offset-deg>1.6</pitch-offset-deg>
+			<heading-offset-deg>81.5</heading-offset-deg>
+			<default-field-of-view-deg type="double">60</default-field-of-view-deg>
+		</config>
+	</view>
+
+    <view n="104">
         <name>Full Cockpit View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
@@ -297,65 +317,13 @@
             <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
             <x-offset-m type="double">0</x-offset-m>
             <y-offset-m type="double">2.242</y-offset-m>
-            <z-offset-m type="double">-26.3</z-offset-m>
+            <z-offset-m type="double">-25.21</z-offset-m>
             <pitch-offset-deg>-14.5</pitch-offset-deg>
             <default-field-of-view-deg type="double">105</default-field-of-view-deg>
         </config>
     </view>
 
-    <view n="104">
-        <name>EFB View</name>
-        <type>lookfrom</type>
-        <internal type="bool">true</internal>
-        <cockpit type="bool">true</cockpit>
-        <config>
-            <from-model type="bool">true</from-model>
-            <from-model-idx type="int">0</from-model-idx>
-            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-            <x-offset-m type="double">-0.955</x-offset-m>
-            <y-offset-m type="double">1.75</y-offset-m>
-            <z-offset-m type="double">-26.9902</z-offset-m>
-            <pitch-offset-deg>-48.6</pitch-offset-deg>
-            <heading-offset-deg>48.6</heading-offset-deg>
-            <default-field-of-view-deg type="double">75</default-field-of-view-deg>
-        </config>
-    </view>
-
     <view n="105">
-        <name>CDU View</name>
-        <type>lookfrom</type>
-        <internal type="bool">true</internal>
-        <cockpit type="bool">true</cockpit>
-        <config>
-            <from-model type="bool">true</from-model>
-            <from-model-idx type="int">0</from-model-idx>
-            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-            <x-offset-m type="double">0</x-offset-m>
-            <y-offset-m type="double">2.4</y-offset-m>
-            <z-offset-m type="double">-27.3</z-offset-m>
-            <pitch-offset-deg>-90</pitch-offset-deg>
-            <default-field-of-view-deg type="double">37</default-field-of-view-deg>
-        </config>
-    </view>
-
-    <view n="106">
-        <name>Overhead Panel View</name>
-        <type>lookfrom</type>
-        <internal type="bool">true</internal>
-        <cockpit type="bool">true</cockpit>
-        <config>
-            <from-model type="bool">true</from-model>
-            <from-model-idx type="int">0</from-model-idx>
-            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-            <x-offset-m type="double">0</x-offset-m>
-            <y-offset-m type="double">1.5</y-offset-m>
-            <z-offset-m type="double">26.0517</z-offset-m>
-            <pitch-offset-deg>53.1</pitch-offset-deg>
-            <default-field-of-view-deg type="double">70</default-field-of-view-deg>
-        </config>
-    </view>
-
-    <view n="107">
         <name>Copilot View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
@@ -364,7 +332,7 @@
             <from-model type="bool">true</from-model>
             <from-model-idx type="int">0</from-model-idx>
             <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
-            <default-field-of-view-deg type="double">60.0</default-field-of-view-deg>
+            <default-field-of-view-deg type="double">90.0</default-field-of-view-deg>
             <default-pitch-deg type="double">0</default-pitch-deg>
             <default-heading-deg type="double">0</default-heading-deg>
             <front-direction-deg type="double">0</front-direction-deg>
@@ -376,13 +344,65 @@
             <right-direction-deg type="double">270</right-direction-deg>
             <front-right-direction-deg type="double">315</front-right-direction-deg>
             <x-offset-m type="double">0.603</x-offset-m>
-            <y-offset-m type="double">2.08</y-offset-m>
-            <z-offset-m type="double">-26.2</z-offset-m>
+            <y-offset-m type="double">2.242</y-offset-m>
+            <z-offset-m type="double">-25.862</z-offset-m>
             <pitch-offset-deg>-10.3</pitch-offset-deg>
         </config>
         <dynamic>
             <enabled type="bool" userarchive="y">false</enabled>
         </dynamic>
+    </view>
+
+    <view n="106">
+        <name>EFB View</name>
+        <type>lookfrom</type>
+        <internal type="bool">true</internal>
+        <cockpit type="bool">true</cockpit>
+        <config>
+            <from-model type="bool">true</from-model>
+            <from-model-idx type="int">0</from-model-idx>
+            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+            <x-offset-m type="double">-0.785</x-offset-m>
+            <y-offset-m type="double">2.04</y-offset-m>
+            <z-offset-m type="double">-26.16</z-offset-m>
+            <pitch-offset-deg>-46.6</pitch-offset-deg>
+            <heading-offset-deg>49.275</heading-offset-deg>
+            <default-field-of-view-deg type="double">50</default-field-of-view-deg>
+        </config>
+    </view>
+
+    <view n="107">
+        <name>CDU View</name>
+        <type>lookfrom</type>
+        <internal type="bool">true</internal>
+        <cockpit type="bool">true</cockpit>
+        <config>
+            <from-model type="bool">true</from-model>
+            <from-model-idx type="int">0</from-model-idx>
+            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+            <x-offset-m type="double">0</x-offset-m>
+            <y-offset-m type="double">2.3</y-offset-m>
+            <z-offset-m type="double">-26.33</z-offset-m>
+            <pitch-offset-deg>-73</pitch-offset-deg>
+            <default-field-of-view-deg type="double">41</default-field-of-view-deg>
+        </config>
+    </view>
+
+    <view n="108">
+        <name>Overhead Panel View</name>
+        <type>lookfrom</type>
+        <internal type="bool">true</internal>
+        <cockpit type="bool">true</cockpit>
+        <config>
+            <from-model type="bool">true</from-model>
+            <from-model-idx type="int">0</from-model-idx>
+            <ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+            <x-offset-m type="double">0</x-offset-m>
+            <y-offset-m type="double">1.8</y-offset-m>
+            <z-offset-m type="double">-25.7</z-offset-m>
+            <pitch-offset-deg>62.9</pitch-offset-deg>
+            <default-field-of-view-deg type="double">78</default-field-of-view-deg>
+        </config>
     </view>
 
         <menubar>

--- a/787-9-Trent-set.xml
+++ b/787-9-Trent-set.xml
@@ -353,7 +353,24 @@
         </dynamic>
     </view>
 
-    <view n="106">
+	<view n="106">
+		<name>Center Console View</name>
+		<type>lookfrom</type>
+		<internal type="bool">true</internal>
+		<cockpit type="bool">true</cockpit>
+		<config>
+			<from-model type="bool">true</from-model>
+			<from-model-idx type="int">0</from-model-idx>
+			<ground-level-nearplane-m type="double">0.5f</ground-level-nearplane-m>
+			<x-offset-m type="double">0</x-offset-m>
+			<y-offset-m type="double">1.81</y-offset-m>
+			<z-offset-m type="double">-26.11</z-offset-m>
+			<pitch-offset-deg>-72.2</pitch-offset-deg>
+			<default-field-of-view-deg type="double">90</default-field-of-view-deg>
+		</config>
+	</view>
+
+    <view n="107">
         <name>EFB View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
@@ -371,7 +388,7 @@
         </config>
     </view>
 
-    <view n="107">
+    <view n="108">
         <name>CDU View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
@@ -388,7 +405,7 @@
         </config>
     </view>
 
-    <view n="108">
+    <view n="109">
         <name>Overhead Panel View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>

--- a/Systems/flight-recorder.xml
+++ b/Systems/flight-recorder.xml
@@ -21,7 +21,6 @@
         </signals>
 
         <!-- Add custom properties here -->
-        <!-- TODO: Add flaps -->
 
         <signal>
             <type>bool</type>

--- a/Systems/flight-recorder.xml
+++ b/Systems/flight-recorder.xml
@@ -21,6 +21,7 @@
         </signals>
 
         <!-- Add custom properties here -->
+        <!-- TODO: Add flaps -->
 
         <signal>
             <type>bool</type>


### PR DESCRIPTION
This PR fixes the view positions and angles across the 3 variants of the 787.

In particular, these views were badly out of place across the variants:
- EFB View
- CDU View
- Overhead Panel View

All of the view positions were fixed, and slightly reorganized grouping all of the cockpit views on one side and the exterior views on the other side.

I also took the liberty to change of FOVs for the Pilot Views and Right Engine Views. However, this can be easily changed if you don't like it.