### PR TITLE
Fixes the pushback truck's alignment with the wheels and rotation

### DIFF
--- a/Models/787-10-GEnx.xml
+++ b/Models/787-10-GEnx.xml
@@ -281,7 +281,8 @@
  <name>Pushback</name>
  <path>Autopush/Goldhofert.xml</path>
  <offsets>
-  <x-m>-25.54268</x-m>
+ <!-- The truck should be -0.346 x-m from the plane's nose wheel -->
+  <x-m>-27.201</x-m>
   <y-m>0</y-m>
   <z-m>-3.55</z-m>
  </offsets>

--- a/Models/787-10-Trent1000.xml
+++ b/Models/787-10-Trent1000.xml
@@ -281,7 +281,8 @@
  <name>Pushback</name>
  <path>Autopush/Goldhofert.xml</path>
  <offsets>
-  <x-m>-25.54268</x-m>
+ <!-- The truck should be -0.346 x-m from the plane's nose wheel -->
+  <x-m>-27.201</x-m>
   <y-m>0</y-m>
   <z-m>-3.55</z-m>
  </offsets>

--- a/Models/787-8-GEnx.xml
+++ b/Models/787-8-GEnx.xml
@@ -281,7 +281,8 @@
  <name>Pushback</name>
  <path>Autopush/Goldhofert.xml</path>
  <offsets>
-  <x-m>-25.54268</x-m>
+ <!-- The truck should be -0.346 x-m from the plane's nose wheel -->
+  <x-m>-20.935</x-m>
   <y-m>0</y-m>
   <z-m>-3.55</z-m>
  </offsets>

--- a/Models/787-8-Trent1000.xml
+++ b/Models/787-8-Trent1000.xml
@@ -281,7 +281,8 @@
  <name>Pushback</name>
  <path>Autopush/Goldhofert.xml</path>
  <offsets>
-  <x-m>-25.54268</x-m>
+ <!-- The truck should be -0.346 x-m from the plane's nose wheel -->
+  <x-m>-20.935</x-m>
   <y-m>0</y-m>
   <z-m>-3.55</z-m>
  </offsets>

--- a/Models/787-9-GEnx.xml
+++ b/Models/787-9-GEnx.xml
@@ -281,7 +281,8 @@
  <name>Pushback</name>
  <path>Autopush/Goldhofert.xml</path>
  <offsets>
-  <x-m>-25.54268</x-m>
+ <!-- The truck should be -0.346 x-m from the plane's nose wheel -->
+  <x-m>-24.181</x-m>
   <y-m>0</y-m>
   <z-m>-3.55</z-m>
  </offsets>

--- a/Models/787-9-Trent1000.xml
+++ b/Models/787-9-Trent1000.xml
@@ -281,7 +281,8 @@
  <name>Pushback</name>
  <path>Autopush/Goldhofert.xml</path>
  <offsets>
-  <x-m>-25.54268</x-m>
+ <!-- The truck should be -0.346 x-m from the plane's nose wheel -->
+  <x-m>-24.181</x-m>
   <y-m>0</y-m>
   <z-m>-3.55</z-m>
  </offsets>

--- a/Models/Autopush/Goldhofert.xml
+++ b/Models/Autopush/Goldhofert.xml
@@ -111,7 +111,7 @@ Distribute under the terms of GPLv2.
    <property>&YAW-PROP;</property>
    <factor>&YAW-MULT;</factor>
    <center>
-     <x-m>0</x-m>
+     <x-m>0.346</x-m>
      <y-m>0</y-m>
      <z-m>0</z-m>
    </center>


### PR DESCRIPTION
Across the 3 variants, the pushback truck was incorrectly aligned with the wheels.

This PR fixes the alignment for the 3 variants and adjusts the truck's rotation center to keep the wheels in alignment when steering.