### PR TITLE
Fix autopilot panel button light animations

### DIFF
--- a/Models/FlightDeck/b787.flightdeck.xml
+++ b/Models/FlightDeck/b787.flightdeck.xml
@@ -2917,7 +2917,7 @@
     <animation>
         <type>pick</type>
         <object-name>APmaster</object-name>
-        <object-name>APtoggle</object-name>
+        <object-name>AP.toggle</object-name>
         <action>
             <button>0</button>
             <binding>
@@ -2985,10 +2985,9 @@
         <action>
             <button>0</button>
             <binding>
-                <command>property-cycle</command>
+                <command>property-assign</command>
                 <property>/it-autoflight/input/lat</property>
 				<value>1</value>
-				<value></value>
             </binding>
         </action>
     </animation>
@@ -3016,10 +3015,9 @@
         <action>
             <button>0</button>
             <binding>
-                <command>property-cycle</command>
+                <command>property-assign</command>
                 <property>/it-autoflight/input/lat</property>
 				<value>0</value>
-				<value></value>
             </binding>
         </action>
     </animation>
@@ -3034,7 +3032,6 @@
                 <command>property-cycle</command>
                 <property>/it-autoflight/input/vert</property>
 				<value>1</value>
-				<value></value>
             </binding>
         </action>
     </animation>
@@ -3046,14 +3043,13 @@
         <action>
             <button>0</button>
             <binding>
-                <command>property-cycle</command>
+                <command>property-assign</command>
                 <property>/it-autoflight/input/vert</property>
 				<value>4</value>
-				<value></value>
             </binding>
         </action>
     </animation>
-    
+
    <animation>
         <type>pick</type>
         <object-name>ALThold</object-name>
@@ -3092,10 +3088,9 @@
         <action>
             <button>0</button>
             <binding>
-                <command>property-cycle</command>
+                <command>property-assign</command>
                 <property>/it-autoflight/input/lat</property>
 				<value>2</value>
-				<value></value>
             </binding>
         </action>
     </animation>
@@ -3107,10 +3102,9 @@
         <action>
             <button>0</button>
             <binding>
-                <command>property-cycle</command>
+                <command>property-assign</command>
                 <property>/it-autoflight/input/vert</property>
 				<value>2</value>
-				<value></value>
             </binding>
         </action>
     </animation>

--- a/Models/FlightDeck/b787.flightdeck.xml
+++ b/Models/FlightDeck/b787.flightdeck.xml
@@ -3119,7 +3119,7 @@
 		<type>select</type>
 		<object-name>AP.toggle</object-name>
 		<condition>
-			<property>/it-autoflight/input/ap1</property>
+            <property>/it-autoflight/output/ap1</property>
 		</condition>
 	</animation>
 
@@ -3127,10 +3127,17 @@
 		<type>select</type>
 		<object-name>APP.toggle</object-name>
 		<condition>
-			<equals>
-				<property>/it-autoflight/input/vert</property>
-				<value>2</value>
-			</equals>
+            <or>
+                <property>/it-autoflight/output/appr-armed</property>
+                <equals>
+                    <property>/it-autoflight/output/vert</property>
+                    <value>2</value>
+                </equals>
+                <equals>
+                    <property>/it-autoflight/output/vert</property>
+                    <value>6</value>
+                </equals>
+            </or>
 		</condition>
 	</animation>
 
@@ -3138,11 +3145,19 @@
 		<type>select</type>
 		<object-name>LOC.toggle</object-name>
 		<condition>
-			<equals>
-				<property>/it-autoflight/input/lat</property>
-				<value>2</value>
-			</equals>
+            <or>
+                <property>/it-autoflight/output/loc-armed</property>
+                <equals>
+                    <property>/it-autoflight/output/lat</property>
+                    <value>2</value>
+                </equals>
+                <equals>
+                    <property>/it-autoflight/output/lat</property>
+                    <value>4</value>
+                </equals>
+            </or>
 		</condition>
+
 	</animation>
 
 	<animation>
@@ -3150,20 +3165,26 @@
 		<object-name>ALT.toggle</object-name>
 		<condition>
 			<equals>
-				<property>/it-autoflight/input/vert</property>
-				<value>0</value>
+				<property>/it-autoflight/output/vert</property>
+                <value>0</value>
 			</equals>
 		</condition>
 	</animation>
-	
-		<animation>
+
+    <animation>
 		<type>select</type>
 		<object-name>FLCH.toggle</object-name>
 		<condition>
-			<equals>
-				<property>/it-autoflight/input/vert</property>
-				<value>4</value>
-			</equals>
+            <or>
+                <equals>
+                    <property>/it-autoflight/output/vert</property>
+                    <value>4</value>
+                </equals>
+                <equals>
+                    <property>/it-autoflight/output/vert</property>
+                    <value>7</value>
+                </equals>
+            </or>
 		</condition>
 	</animation>
 
@@ -3171,10 +3192,10 @@
 		<type>select</type>
 		<object-name>HDG.toggle</object-name>
 		<condition>
-			<equals>
-				<property>/it-autoflight/input/lat</property>
-				<value>0</value>
-			</equals>
+            <equals>
+                <property>/it-autoflight/output/lat</property>
+                <value>0</value>
+            </equals>
 		</condition>
 	</animation>
 
@@ -3183,8 +3204,8 @@
 		<object-name>VS.toggle</object-name>
 		<condition>
 			<equals>
-				<property>/it-autoflight/input/vert</property>
-				<value>1</value>
+				<property>/it-autoflight/output/vert</property>
+                <value>1</value>
 			</equals>
 		</condition>
 	</animation>
@@ -3193,10 +3214,13 @@
 		<type>select</type>
 		<object-name>LNAV.toggle</object-name>
 		<condition>
-			<equals>
-				<property>/it-autoflight/input/lat</property>
-				<value>1</value>
-			</equals>
+            <or>
+                <property>/it-autoflight/output/lnav-armed</property>
+                <equals>
+                    <property>/it-autoflight/output/lat</property>
+                    <value>1</value>
+                </equals>
+            </or>
 		</condition>
 	</animation>
 
@@ -3215,7 +3239,7 @@
 		<type>select</type>
 		<object-name>AT.toggle</object-name>
 		<condition>
-			<property>/it-autoflight/input/athr</property>
+			<property>/it-autoflight/output/athr</property>
 		</condition>
 	</animation>
 

--- a/Models/FlightDeck/b787.flightdeck.xml
+++ b/Models/FlightDeck/b787.flightdeck.xml
@@ -3117,6 +3117,26 @@
 		</condition>
 	</animation>
 
+    <animation>
+        <type>material</type>
+        <object-name>AP.toggle</object-name>
+        <object-name>AT.toggle</object-name>
+        <object-name>LNAV.toggle</object-name>
+        <object-name>VNAV.toggle</object-name>
+        <object-name>FLCH.toggle</object-name>
+        <object-name>HDG.toggle</object-name>
+        <object-name>VS.toggle</object-name>
+        <object-name>ALT.toggle</object-name>
+        <object-name>LOC.toggle</object-name>
+        <object-name>APP.toggle</object-name>
+        <emission>
+            <red>0</red>
+            <green>0.6</green>
+            <blue>0</blue>
+            <factor-prop>controls/lighting/master-bright</factor-prop>
+        </emission>
+    </animation>
+
 	<animation>
 		<type>select</type>
 		<object-name>APP.toggle</object-name>


### PR DESCRIPTION
The button lights **would not update** with the current autopilot mode, so the animation were updated to depend on `/it-autoflight/output/...` instead of `/it-autoflight/input/...`.

This also required changing some of the logic and conditions on which the button illuminate.

The values on which the animations depend now were referenced from the [IT-AUTOFLIGHT - FlightGear wiki: SDK](https://wiki.flightgear.org/IT-AUTOFLIGHT#SDK).