### PR TITLE
Use autobrake knob with scrollwheel

### DIFF
--- a/Models/FlightDeck/b787.flightdeck.xml
+++ b/Models/FlightDeck/b787.flightdeck.xml
@@ -2592,15 +2592,38 @@
 			<binding>
 				<command>property-cycle</command>
 				<property>controls/autobrake/setting</property>
+				<value>-1</value>
 				<value>0</value>
 				<value>1</value>
 				<value>2</value>
 				<value>3</value>
 				<value>4</value>
 				<value>5</value>
-				<value>6</value>
 			</binding>
 		</action>
+
+        <action>
+            <button>3</button>
+            <repeatable type="bool">true</repeatable>
+            <binding>
+                <command>property-adjust</command>
+                <property>controls/autobrake/setting</property>
+                <step>1</step>
+                <min>-1</min>
+                <max>5</max>
+            </binding>
+        </action>
+        <action>
+            <button>4</button>
+            <repeatable type="bool">true</repeatable>
+            <binding>
+                <command>property-adjust</command>
+                <property>controls/autobrake/setting</property>
+                <step>-1</step>
+                <min>-1</min>
+                <max>5</max>
+            </binding>
+        </action>
 	</animation>
 
 	<animation>
@@ -2608,13 +2631,13 @@
 		<object-name>autobrake</object-name>
 		<property>controls/autobrake/setting</property>
 		<interpolation>
+			<entry><ind>-1</ind><dep>-120</dep></entry>
 			<entry><ind>0</ind><dep>-90</dep></entry>
 			<entry><ind>1</ind><dep>-20</dep></entry>
 			<entry><ind>2</ind><dep>10</dep></entry>
 			<entry><ind>3</ind><dep>40</dep></entry>
 			<entry><ind>4</ind><dep>70</dep></entry>
 			<entry><ind>5</ind><dep>90</dep></entry>
-			<entry><ind>6</ind><dep>-120</dep></entry>
 		</interpolation>
 		<axis>
 			<x1-m>-23.7217</x1-m>

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -58,10 +58,10 @@ var autobrake = {
         # Deactivate autobrake after rollout, even from RTO. There's some slack for the throttle
         # setting to taxi after rollout.
         if (
-            (getprop("/velocities/airspeed-kt") < 40)                   # Airspeed is low
-            and (getprop("/gear/gear[0]/rollspeed-ms") > 5)             # The aircraft is rolling
-            and (getprop("/gear/gear[0]/compression-ft") != 0)        # The aircraft is on the ground
-            and (getprop("/controls/engines/engine[0]/throttle") < 0.3) # Throttle is set to taxi
+            (getprop("/velocities/airspeed-kt") < 40)                  # Airspeed is low
+            and (getprop("/gear/gear[0]/rollspeed-ms") > 5)            # The aircraft is rolling
+            and (getprop("/gear/gear[0]/compression-ft") != 0)         # The aircraft is on the ground
+            and (getprop("/controls/engines/engine[0]/throttle") == 0) # Throttle is set to idle
         ) {
             setprop("/controls/autobrake/setting", 0);
         }

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -55,26 +55,26 @@ var autobrake = {
             }
         }
 
-		# Deactivate autobrake after rollout, even from RTO. There's some slack for the throttle
-		# setting to taxi after rollout.
-		if (
-			(getprop("/velocities/airspeed-kt") < 40)                   # Airspeed is low
-			and (getprop("/gear/gear[0]/rollspeed-ms") > 5)             # The aircraft is rolling
-            and (getprop("/gear/gear[0]/compression-norm") != 0)        # The aircraft is on the ground
-			and (getprop("/controls/engines/engine[0]/throttle") < 0.3) # Throttle is set to taxi
-		) {
-			setprop("/controls/autobrake/setting", 0);
-		}
+        # Deactivate autobrake after rollout, even from RTO. There's some slack for the throttle
+        # setting to taxi after rollout.
+        if (
+            (getprop("/velocities/airspeed-kt") < 40)                   # Airspeed is low
+            and (getprop("/gear/gear[0]/rollspeed-ms") > 5)             # The aircraft is rolling
+            and (getprop("/gear/gear[0]/compression-ft") != 0)        # The aircraft is on the ground
+            and (getprop("/controls/engines/engine[0]/throttle") < 0.3) # Throttle is set to taxi
+        ) {
+            setprop("/controls/autobrake/setting", 0);
+        }
 
-		# Deactivate autobrake after takeoff
-		if (
-			(getprop("/velocities/airspeed-kt") > 120)                  # Airspeed is high
-            and (getprop("velocities/gear[0]/rollspeed-ms") > 25)       # Aircraft was recently on the ground
-			and (getprop("/gear/gear[0]/compression-norm") == 0)        # The aircraft is flying
-			and (getprop("/controls/engines/engine[0]/throttle") > 0.9) # Throttle is set to takeoff
-		) {
-			setprop("/controls/autobrake/setting", 0);
-		}
+        # Deactivate autobrake after takeoff
+        if (
+            (getprop("/velocities/airspeed-kt") > 120)                  # Airspeed is high
+            and (getprop("/gear/gear[0]/rollspeed-ms") > 25)            # Aircraft was recently on the ground
+            and (getprop("/gear/gear[0]/compression-ft") == 0)          # The aircraft is flying
+            and (getprop("/controls/engines/engine[0]/throttle") > 0.9) # Throttle is set to takeoff
+        ) {
+            setprop("/controls/autobrake/setting", 0);
+        }
     },
     reset : func {
         me.loopid += 1;

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -58,18 +58,20 @@ var autobrake = {
 		# Deactivate autobrake after rollout, even from RTO. There's some slack for the throttle
 		# setting to taxi after rollout.
 		if (
-			(getprop("/velocities/airspeed-kt") < 40)
-			and (getprop("/gear/gear[0]/rollspeed-ms") > 5)
-			and (getprop("/controls/engines/engine[0]/throttle") < 0.3)
+			(getprop("/velocities/airspeed-kt") < 40)                   # Airspeed is low
+			and (getprop("/gear/gear[0]/rollspeed-ms") > 5)             # The aircraft is rolling
+            and (getprop("/gear/gear[0]/compression-norm") != 0)        # The aircraft is on the ground
+			and (getprop("/controls/engines/engine[0]/throttle") < 0.3) # Throttle is set to taxi
 		) {
 			setprop("/controls/autobrake/setting", 0);
 		}
 
 		# Deactivate autobrake after takeoff
 		if (
-			(getprop("/velocities/airspeed-kt") > 120)
-			and (getprop("/gear/gear[0]/compression-norm") == 0)
-			and (getprop("/controls/engines/engine[0]/throttle") > 0.9)
+			(getprop("/velocities/airspeed-kt") > 120)                  # Airspeed is high
+            and (getprop("velocities/gear[0]/rollspeed-ms") > 25)       # Aircraft was recently on the ground
+			and (getprop("/gear/gear[0]/compression-norm") == 0)        # The aircraft is flying
+			and (getprop("/controls/engines/engine[0]/throttle") > 0.9) # Throttle is set to takeoff
 		) {
 			setprop("/controls/autobrake/setting", 0);
 		}

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -53,11 +53,26 @@ var autobrake = {
                     me.fullthrottle = 0;
                 }
             }
-
-            if (getprop("/velocities/airspeed-kt") < 40) {
-                setprop("/controls/autobrake/setting", 0);
-            }
         }
+
+		# Deactivate autobrake after rollout, even from RTO. There's some slack for the throttle
+		# setting to taxi after rollout.
+		if (
+			(getprop("/velocities/airspeed-kt") < 40)
+			and (getprop("/gear/gear[0]/rollspeed-ms") > 5)
+			and (getprop("/controls/engines/engine[0]/throttle") < 0.3)
+		) {
+			setprop("/controls/autobrake/setting", 0);
+		}
+
+		# Deactivate autobrake after takeoff
+		if (
+			(getprop("/velocities/airspeed-kt") > 120)
+			and (getprop("/gear/gear[0]/compression-norm") == 0)
+			and (getprop("/controls/engines/engine[0]/throttle") > 0.9)
+		) {
+			setprop("/controls/autobrake/setting", 0);
+		}
     },
     reset : func {
         me.loopid += 1;

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -1,69 +1,64 @@
 var autobrake = {
-	init : func { 
-        me.UPDATE_INTERVAL = 0.5; 
-        me.loopid = 0; 
-	me.fullthrottle = 0;
-setprop("/controls/autobrake/setting", 0);
+    init : func {
+        me.UPDATE_INTERVAL = 0.5;
+        me.loopid = 0;
+        me.fullthrottle = 0;
+        setprop("/controls/autobrake/setting", 0);
 
-        me.reset(); 
-}, 
-	update : func {
+        me.reset();
+    },
+    update : func {
+        var absetting = getprop("/controls/autobrake/setting");
 
-var absetting = getprop("/controls/autobrake/setting");
+        if ((getprop("/velocities/airspeed-kt") >= 40) and (getprop("/gear/gear[0]/rollspeed-ms") > 5)) {
+            # ABS LOW 1
+            if (absetting == 1) {
+                setprop("controls/gear/brake-left", 0.2);
+                setprop("controls/gear/brake-right", 0.2);
+            }
 
-if ((getprop("/velocities/airspeed-kt") >= 40) and (getprop("/gear/gear[0]/rollspeed-ms") > 5)) {
+            # ABS LOW 2
+            if (absetting == 2) {
+                setprop("controls/gear/brake-left", 0.4);
+                setprop("controls/gear/brake-right", 0.4);
+            }
 
-# ABS LOW 1
-if (absetting == 1) {
-setprop("controls/gear/brake-left", 0.2);
-setprop("controls/gear/brake-right", 0.2);
-}
+            # ABS MED 3
+            if (absetting == 3) {
+                setprop("controls/gear/brake-left", 0.6);
+                setprop("controls/gear/brake-right", 0.6);
+            }
 
-# ABS LOW 2
-if (absetting == 2) {
-setprop("controls/gear/brake-left", 0.4);
-setprop("controls/gear/brake-right", 0.4);
-}
+            # ABS HIGH 4
+                if (absetting == 4) {
+                setprop("controls/gear/brake-left", 0.8);
+                setprop("controls/gear/brake-right", 0.8);
+            }
 
-# ABS MED 3
-if (absetting == 3) {
-setprop("controls/gear/brake-left", 0.6);
-setprop("controls/gear/brake-right", 0.6);
-}
+            # ABS MAX 5
+            if (absetting == 5) {
+                setprop("controls/gear/brake-left", 1);
+                setprop("controls/gear/brake-right", 1);
+            }
 
-# ABS HIGH 4
-if (absetting == 4) {
-setprop("controls/gear/brake-left", 0.8);
-setprop("controls/gear/brake-right", 0.8);
-}
+            # ABS RTO
+            if (absetting == 6) {
+                if (getprop("controls/engines/engine[0]/throttle") >= 0.9) {
+                    me.fullthrottle = 1;
+                }
 
-# ABS MAX 5
-if (absetting == 5) {
-setprop("controls/gear/brake-left", 1);
-setprop("controls/gear/brake-right", 1);
-}
+                if ((me.fullthrottle == 1) and (getprop("controls/engines/engine[0]/throttle") <= 0.6)) {
+                    setprop("controls/gear/brake-left", 1);
+                    setprop("controls/gear/brake-right", 1);
+                    me.fullthrottle = 0;
+                }
+            }
 
-# ABS RTO
-if (absetting == 6) {
-if (getprop("controls/engines/engine[0]/throttle") >= 0.9) {
-me.fullthrottle = 1;
-}
-
-if ((me.fullthrottle == 1) and (getprop("controls/engines/engine[0]/throttle") <= 0.6)) {
-setprop("controls/gear/brake-left", 1);
-setprop("controls/gear/brake-right", 1);
-me.fullthrottle = 0;
-}
-
-}
-
-if (getprop("/velocities/airspeed-kt") < 40) {
-    setprop("/controls/autobrake/setting", 0);
-}
-
-}
-
-},
+            if (getprop("/velocities/airspeed-kt") < 40) {
+                setprop("/controls/autobrake/setting", 0);
+            }
+        }
+    },
     reset : func {
         me.loopid += 1;
         me._loop_(me.loopid);
@@ -73,12 +68,10 @@ if (getprop("/velocities/airspeed-kt") < 40) {
         me.update();
         settimer(func { me._loop_(id); }, me.UPDATE_INTERVAL);
     }
-
 };
 
-setlistener("sim/signals/fdm-initialized", func
- {
- autobrake.init();
- print("Autobrake System .... Initialized");
- sysinfo.log_msg("[ABS] Autobrake System Initialized", 0); 
- });
+setlistener("sim/signals/fdm-initialized", func {
+    autobrake.init();
+    print("Autobrake System .... Initialized");
+    sysinfo.log_msg("[ABS] Autobrake System Initialized", 0);
+});

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -42,7 +42,7 @@ var autobrake = {
             }
 
             # ABS RTO
-            if (absetting == 6) {
+            if (absetting == -1) {
                 if (getprop("controls/engines/engine[0]/throttle") >= 0.9) {
                     me.fullthrottle = 1;
                 }


### PR DESCRIPTION
The autobrake knob could only be used with the left click, when it could also be used with the scroll-wheel.

This PR makes that possible, and knob won't repeat the settings using the scrollwheel so you can't go from `RTO` to `Autobrake MAX` by accident if you scroll down, just like you won't go from `Autobrake MAX` to `RTO` by scrolling up.

I also did some formatting for clarity and coding in the [`autobrake.nas`](Nasal/autobrake.nas) file to auto-deactivate the automatic brakes after rollout and/or after takeoff.