### PR TITLE
Use autobrake knob with scrollwheel + auto-deactivate autobrakes

### DIFF
--- a/787-10-GEnx-set.xml
+++ b/787-10-GEnx-set.xml
@@ -866,6 +866,9 @@
             </copilot>
             <ind type="bool">1</ind>
         </switches>
+        <autobrake>
+            <possible-rto type="bool">false</possible-rto>
+        </autobrake>
     </controls>
 
     <engines>

--- a/787-10-Trent-set.xml
+++ b/787-10-Trent-set.xml
@@ -866,6 +866,9 @@
             </copilot>
             <ind type="bool">1</ind>
         </switches>
+        <autobrake>
+            <possible-rto type="bool">false</possible-rto>
+        </autobrake>
     </controls>
 
     <engines>

--- a/787-8-GEnx-set.xml
+++ b/787-8-GEnx-set.xml
@@ -861,6 +861,9 @@
             </copilot>
             <ind type="bool">1</ind>
         </switches>
+        <autobrake>
+            <possible-rto type="bool">false</possible-rto>
+        </autobrake>
     </controls>
 
     <engines>

--- a/787-8-Trent-set.xml
+++ b/787-8-Trent-set.xml
@@ -860,6 +860,9 @@
             </copilot>
             <ind type="bool">1</ind>
         </switches>
+        <autobrake>
+            <possible-rto type="bool">false</possible-rto>
+        </autobrake>
     </controls>
 
     <engines>

--- a/787-9-GEnx-set.xml
+++ b/787-9-GEnx-set.xml
@@ -866,6 +866,9 @@
             </copilot>
             <ind type="bool">1</ind>
         </switches>
+        <autobrake>
+            <possible-rto type="bool">false</possible-rto>
+        </autobrake>
     </controls>
 
     <engines>

--- a/787-9-Trent-set.xml
+++ b/787-9-Trent-set.xml
@@ -866,6 +866,9 @@
             </copilot>
             <ind type="bool">1</ind>
         </switches>
+        <autobrake>
+            <possible-rto type="bool">false</possible-rto>
+        </autobrake>
     </controls>
 
     <engines>

--- a/787-common.xml
+++ b/787-common.xml
@@ -99,11 +99,23 @@
                 <name>Ctrl-b</name>
                 <desc>Cycle speedbrake setting</desc>
                 <binding>
-                    <command>property-cycle</command>
-                    <property>controls/flight/speedbrake-lever</property>
-                    <value>0</value>
-                    <value>0.5</value>
-                    <value>1</value>
+                    <command>nasal</command>
+                    <script><![CDATA[
+                        var lever = "controls/flight/speedbrake-lever";
+                        var auto = "controls/flight/speedbrake-auto";
+
+                        if (getprop(auto) == 1) {
+                            setprop(lever, 0.0);
+                            setprop(auto, 0);
+                            return;
+                        }
+
+                        var setting = getprop(lever) + 0.5;
+                        if (setting > 1) {
+                            setting = 0;
+                        }
+                        setprop(lever, setting);
+                        ]]></script>
                 </binding>
             </key>
             <key n="11">

--- a/Models/FlightDeck/b787.flightdeck.xml
+++ b/Models/FlightDeck/b787.flightdeck.xml
@@ -2586,6 +2586,8 @@
 	<animation>
 		<type>pick</type>
 		<object-name>autobrake</object-name>
+
+        <!-- Cycle using left click -->
 		<action>
 			<button>0</button>
 			<repeatable type="bool">false</repeatable>
@@ -2603,6 +2605,18 @@
 			</binding>
 		</action>
 
+        <!-- Set to OFF using right click -->
+        <action>
+            <button>2</button>
+            <repetable type="bool">false</repetable>
+            <binding>
+                <command>property-assign</command>
+                <property>controls/autobrake/setting</property>
+                <value>0</value>
+            </binding>
+        </action>
+
+        <!-- Adjust using mouse wheel -->
         <action>
             <button>3</button>
             <repeatable type="bool">true</repeatable>

--- a/Models/FlightDeck/b787.flightdeck.xml
+++ b/Models/FlightDeck/b787.flightdeck.xml
@@ -2592,15 +2592,38 @@
 			<binding>
 				<command>property-cycle</command>
 				<property>controls/autobrake/setting</property>
+				<value>-1</value>
 				<value>0</value>
 				<value>1</value>
 				<value>2</value>
 				<value>3</value>
 				<value>4</value>
 				<value>5</value>
-				<value>6</value>
 			</binding>
 		</action>
+
+        <action>
+            <button>3</button>
+            <repeatable type="bool">true</repeatable>
+            <binding>
+                <command>property-adjust</command>
+                <property>controls/autobrake/setting</property>
+                <step>1</step>
+                <min>-1</min>
+                <max>5</max>
+            </binding>
+        </action>
+        <action>
+            <button>4</button>
+            <repeatable type="bool">true</repeatable>
+            <binding>
+                <command>property-adjust</command>
+                <property>controls/autobrake/setting</property>
+                <step>-1</step>
+                <min>-1</min>
+                <max>5</max>
+            </binding>
+        </action>
 	</animation>
 
 	<animation>
@@ -2608,13 +2631,13 @@
 		<object-name>autobrake</object-name>
 		<property>controls/autobrake/setting</property>
 		<interpolation>
+			<entry><ind>-1</ind><dep>-120</dep></entry>
 			<entry><ind>0</ind><dep>-90</dep></entry>
 			<entry><ind>1</ind><dep>-20</dep></entry>
 			<entry><ind>2</ind><dep>10</dep></entry>
 			<entry><ind>3</ind><dep>40</dep></entry>
 			<entry><ind>4</ind><dep>70</dep></entry>
 			<entry><ind>5</ind><dep>90</dep></entry>
-			<entry><ind>6</ind><dep>-120</dep></entry>
 		</interpolation>
 		<axis>
 			<x1-m>-23.7217</x1-m>

--- a/Models/FlightDeck/b787.flightdeck.xml
+++ b/Models/FlightDeck/b787.flightdeck.xml
@@ -2599,6 +2599,7 @@
 				<value>3</value>
 				<value>4</value>
 				<value>5</value>
+				<value>6</value>
 			</binding>
 		</action>
 
@@ -2610,7 +2611,7 @@
                 <property>controls/autobrake/setting</property>
                 <step>1</step>
                 <min>-1</min>
-                <max>5</max>
+                <max>6</max>
             </binding>
         </action>
         <action>
@@ -2621,7 +2622,7 @@
                 <property>controls/autobrake/setting</property>
                 <step>-1</step>
                 <min>-1</min>
-                <max>5</max>
+                <max>6</max>
             </binding>
         </action>
 	</animation>
@@ -2633,11 +2634,12 @@
 		<interpolation>
 			<entry><ind>-1</ind><dep>-120</dep></entry>
 			<entry><ind>0</ind><dep>-90</dep></entry>
-			<entry><ind>1</ind><dep>-20</dep></entry>
-			<entry><ind>2</ind><dep>10</dep></entry>
-			<entry><ind>3</ind><dep>40</dep></entry>
-			<entry><ind>4</ind><dep>70</dep></entry>
-			<entry><ind>5</ind><dep>90</dep></entry>
+			<entry><ind>1</ind><dep>-60</dep></entry>
+			<entry><ind>2</ind><dep>-30</dep></entry>
+			<entry><ind>3</ind><dep>0</dep></entry>
+			<entry><ind>4</ind><dep>30</dep></entry>
+			<entry><ind>5</ind><dep>60</dep></entry>
+			<entry><ind>6</ind><dep>90</dep></entry>
 		</interpolation>
 		<axis>
 			<x1-m>-23.7217</x1-m>

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -18,7 +18,6 @@ var autobrake = {
         if (rear_spin < getprop("gear/gear[2]/rollspeed-ms"))
             rear_spin = getprop("gear/gear[2]/rollspeed-ms");
 
-        # The pressure will be interpolated to go from 0 to 1 in 1 second (or, for eg, 0 to 0.2 in 0.2 seconds)
         var brake_pressure = (absetting - 1) / 5.0;
 
         # Handle disarming events
@@ -31,8 +30,8 @@ var autobrake = {
             and rear_spin > 5
             # The wheels will only be spinning if the aircraft has touched down.
         ) {
-            interpolate("controls/gear/brake-left", 0, brake_pressure / 2);
-            interpolate("controls/gear/brake-right", 0, brake_pressure / 2);
+            setprop("controls/gear/brake-left", 0);
+            setprop("controls/gear/brake-right", 0);
             setprop("controls/autobrake/setting", 1);
             #screen.log.write("Disarming Autobrakes after go-around"); # For testing
         }
@@ -93,8 +92,8 @@ var autobrake = {
                 and current_throttle == 0
             ) {
                 #screen.log.write("Applying autobrakes after RTO"); # For testing
-                interpolate("controls/gear/brake-left", 1, 0.8);
-                interpolate("controls/gear/brake-right", 1, 0.8);
+                setprop("controls/gear/brake-left", 1);
+                setprop("controls/gear/brake-right", 1);
             }
 
             return;
@@ -110,23 +109,23 @@ var autobrake = {
             # sloped runways, so instead we detect that the nose wheel is touching the ground.
             if (!getprop("gear/gear[0]/wow")) {
                 #screen.log.write("Setting Autobrakes to 0.8 MAX"); # For testing
-                interpolate("controls/gear/brake-left", 0.8, 0.8);
-                interpolate("controls/gear/brake-right", 0.8, 0.8);
+                setprop("controls/gear/brake-left", 0.8);
+                setprop("controls/gear/brake-right", 0.8);
                 return;
             }
 
             # Set the brakes to MAX after nose wheel touches the ground.
             #screen.log.write("Setting Autobrakes to 1.0 MAX"); # For testing
-            interpolate("controls/gear/brake-left", 1, 0.2);
-            interpolate("controls/gear/brake-right", 1, 0.2);
+            setprop("controls/gear/brake-left", 1);
+            setprop("controls/gear/brake-right", 1);
 
             return;
         }
 
         # All remaining autobrake settings
         #screen.log.write("Setting autobrakes to " ~ brake_pressure ~ "."); # For testing
-        interpolate("controls/gear/brake-left", brake_pressure, brake_pressure);
-        interpolate("controls/gear/brake-right", brake_pressure, brake_pressure);
+        setprop("controls/gear/brake-left", brake_pressure);
+        setprop("controls/gear/brake-right", brake_pressure);
 
         # The brakes will stay applied until coming to a complete stop or until it's disarmed.
     },

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -58,10 +58,10 @@ var autobrake = {
         # Deactivate autobrake after rollout, even from RTO. There's some slack for the throttle
         # setting to taxi after rollout.
         if (
-            (getprop("/velocities/airspeed-kt") < 40)                   # Airspeed is low
-            and (getprop("/gear/gear[0]/rollspeed-ms") > 5)             # The aircraft is rolling
-            and (getprop("/gear/gear[0]/compression-ft") != 0)        # The aircraft is on the ground
-            and (getprop("/controls/engines/engine[0]/throttle") < 0.3) # Throttle is set to taxi
+            (getprop("/velocities/airspeed-kt") < 40)                  # Airspeed is low
+            and (getprop("/gear/gear[0]/rollspeed-ms") > 5)            # The aircraft is rolling
+            and (getprop("/gear/gear[0]/compression-ft") != 0)         # The aircraft is on the ground
+            and (getprop("/controls/engines/engine[0]/throttle") == 0) # Throttle is set to idle
         ) {
             setprop("/controls/autobrake/setting", 0);
         }

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -15,6 +15,7 @@ var autobrake = {
         var absetting = getprop("controls/autobrake/setting");
 
         # Handle disarming events
+        #########################
 
         # Initiating a go-around after touchdown disarms the system.
         if (
@@ -61,6 +62,7 @@ var autobrake = {
         me.old_spdbrk = current_spdbrk;
 
         # Handle application of brake pressure
+        ######################################
 
         # OFF & DISARM settings
         if ((absetting == 0) or (absetting == 1))

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -2,7 +2,6 @@ var autobrake = {
     init : func {
         me.UPDATE_INTERVAL = 0.5;
         me.loopid = 0;
-        me.fullthrottle = 0;
         me.old_throttle = getprop("controls/engine[0]/throttle");
         me.current_spdbrk = getprop("controls/flight/speedbrake-lever");
         setprop("controls/autobrake/setting", 0);
@@ -74,24 +73,20 @@ var autobrake = {
 
         # RTO setting
         if (absetting == -1) {
-            if (current_throttle >= 0.9)
-                me.fullthrottle = 1;
-
-            if ((me.fullthrottle == 1) and (current_throttle <= 0.6)) {
-                setprop("controls/gear/brake-left", 1);
-                setprop("controls/gear/brake-right", 1);
-                me.fullthrottle == 0;
-                #screen.log.write("Applying autobrakes after RTO"); # For testing
+            # Set to OFF after takeoff
+            if (getprop("gear/gear[1]/compression-ft") == 0) {
+                #screen.log.write("Setting Autobrakes to OFF after takeoff"); # For testing
+                setprop("controls/autobrake/setting", 0);
             }
 
-            # Set autobrake to OFF after takeoff
+            # 43.5 rollspeed means 85 kt ground speed
             if (
-                (getprop("velocities/airspeed-kt") > 150)
-                and (getprop("gear/gear[1]/compression-ft") == 0)
-                and (me.fullthrottle == 1)
+                (getprop("gear/gear[1]/rollspeed-ms") > 43.5)
+                and (current_throttle == 0)
             ) {
-                setprop("controls/autobrake/setting", 0);
-                #screen.log.write("Setting Autobrakes to OFF after takeoff"); # For testing
+                #screen.log.write("Applying autobrakes after RTO"); # For testing
+                setprop("controls/gear/brake-left", 1);
+                setprop("controls/gear/brake-right", 1);
             }
 
             return;

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -55,26 +55,26 @@ var autobrake = {
             }
         }
 
-		# Deactivate autobrake after rollout, even from RTO. There's some slack for the throttle
-		# setting to taxi after rollout.
-		if (
-			(getprop("/velocities/airspeed-kt") < 40)                   # Airspeed is low
-			and (getprop("/gear/gear[0]/rollspeed-ms") > 5)             # The aircraft is rolling
-            and (getprop("/gear/gear[0]/compression-norm") != 0)        # The aircraft is on the ground
-			and (getprop("/controls/engines/engine[0]/throttle") < 0.3) # Throttle is set to taxi
-		) {
-			setprop("/controls/autobrake/setting", 0);
-		}
+        # Deactivate autobrake after rollout, even from RTO. There's some slack for the throttle
+        # setting to taxi after rollout.
+        if (
+            (getprop("/velocities/airspeed-kt") < 40)                   # Airspeed is low
+            and (getprop("/gear/gear[0]/rollspeed-ms") > 5)             # The aircraft is rolling
+            and (getprop("/gear/gear[0]/compression-ft") != 0)        # The aircraft is on the ground
+            and (getprop("/controls/engines/engine[0]/throttle") < 0.3) # Throttle is set to taxi
+        ) {
+            setprop("/controls/autobrake/setting", 0);
+        }
 
-		# Deactivate autobrake after takeoff
-		if (
-			(getprop("/velocities/airspeed-kt") > 120)                  # Airspeed is high
-            and (getprop("velocities/gear[0]/rollspeed-ms") > 25)       # Aircraft was recently on the ground
-			and (getprop("/gear/gear[0]/compression-norm") == 0)        # The aircraft is flying
-			and (getprop("/controls/engines/engine[0]/throttle") > 0.9) # Throttle is set to takeoff
-		) {
-			setprop("/controls/autobrake/setting", 0);
-		}
+        # Deactivate autobrake after takeoff
+        if (
+            (getprop("/velocities/airspeed-kt") > 120)                  # Airspeed is high
+            and (getprop("/gear/gear[0]/rollspeed-ms") > 25)            # Aircraft was recently on the ground
+            and (getprop("/gear/gear[0]/compression-ft") == 0)          # The aircraft is flying
+            and (getprop("/controls/engines/engine[0]/throttle") > 0.9) # Throttle is set to takeoff
+        ) {
+            setprop("/controls/autobrake/setting", 0);
+        }
     },
     reset : func {
         me.loopid += 1;

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -58,18 +58,20 @@ var autobrake = {
 		# Deactivate autobrake after rollout, even from RTO. There's some slack for the throttle
 		# setting to taxi after rollout.
 		if (
-			(getprop("/velocities/airspeed-kt") < 40)
-			and (getprop("/gear/gear[0]/rollspeed-ms") > 5)
-			and (getprop("/controls/engines/engine[0]/throttle") < 0.3)
+			(getprop("/velocities/airspeed-kt") < 40)                   # Airspeed is low
+			and (getprop("/gear/gear[0]/rollspeed-ms") > 5)             # The aircraft is rolling
+            and (getprop("/gear/gear[0]/compression-norm") != 0)        # The aircraft is on the ground
+			and (getprop("/controls/engines/engine[0]/throttle") < 0.3) # Throttle is set to taxi
 		) {
 			setprop("/controls/autobrake/setting", 0);
 		}
 
 		# Deactivate autobrake after takeoff
 		if (
-			(getprop("/velocities/airspeed-kt") > 120)
-			and (getprop("/gear/gear[0]/compression-norm") == 0)
-			and (getprop("/controls/engines/engine[0]/throttle") > 0.9)
+			(getprop("/velocities/airspeed-kt") > 120)                  # Airspeed is high
+            and (getprop("velocities/gear[0]/rollspeed-ms") > 25)       # Aircraft was recently on the ground
+			and (getprop("/gear/gear[0]/compression-norm") == 0)        # The aircraft is flying
+			and (getprop("/controls/engines/engine[0]/throttle") > 0.9) # Throttle is set to takeoff
 		) {
 			setprop("/controls/autobrake/setting", 0);
 		}

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -120,8 +120,8 @@ var autobrake = {
 
         # All remaining autobrake settings
         #screen.log.write("Setting autobrakes to " ~ brake_pressure ~ "."); # For testing
-        interpolate("controls/gear/brake-left", brake_pressure, brake_pressure));
-        interpolate("controls/gear/brake-right", brake_pressure, brake_pressure));
+        interpolate("controls/gear/brake-left", brake_pressure, brake_pressure);
+        interpolate("controls/gear/brake-right", brake_pressure, brake_pressure);
 
         # The brakes will stay applied until coming to a complete stop or until it's disarmed.
     },

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -22,7 +22,7 @@ var autobrake = {
             (absetting > 1)
             and (current_throttle > me.old_throttle)
             and (getprop("gear/gear[1]/rollspeed-ms") > 5)
-            # The rollspeed is used to avoid disarming the system in the takeoff roll.
+            # The wheels will only be spinning if the aircraft has touched down.
         ) {
             setprop("controls/gear/brake-left", 0);
             setprop("controls/gear/brake-right", 0);
@@ -39,8 +39,8 @@ var autobrake = {
 
             #screen.log.write("Disarming Autobrakes after pedal input"); # For testing
             # The fact that `/controls/autobrake/setting` is tied to both the pedal brakes and
-            # autobrakes limits our ability to detect pedal braking to just detecting more or the
-            # same pedal braking than the autobrake setting.
+            # autobrakes limits our ability to detect pedal braking to just detecting more pedal
+            # braking than the autobrake setting.
         }
 
         # Moving the speedbrake lever to down (0) after brakes have deployed on the ground disarms

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -45,7 +45,7 @@ var autobrake = {
         # Moving the speedbrake lever to down (0) after brakes have deployed on the ground disarms
         # the system.
         if (
-            (getprop("gear/gear[1]/compression-ft") != 0)
+            getprop("gear/gear[1]/wow")
             and (getprop("controls/gear/brake-left") > 0)
             and (me.old_spdbrk > 0)
             and (current_spdbrk == 0)
@@ -74,7 +74,7 @@ var autobrake = {
         # RTO setting
         if (absetting == -1) {
             # Set to OFF after takeoff
-            if (getprop("gear/gear[1]/compression-ft") == 0) {
+            if (!getprop("gear/gear[1]/wow")) {
                 #screen.log.write("Setting Autobrakes to OFF after takeoff"); # For testing
                 setprop("controls/autobrake/setting", 0);
             }
@@ -100,7 +100,7 @@ var autobrake = {
         if (absetting == 6) {
             # We should be detecting a pitch angle lower than 1°, but this can be unreliable in
             # sloped runways, so instead we detect that the nose wheel is touching the ground.
-            if (getprop("gear/gear[0]/compression-ft") == 0) {
+            if (!getprop("gear/gear[0]/wow")) {
                 #screen.log.write("Setting Autobrakes to 0.8 MAX"); # For testing
                 interpolate("controls/gear/brake-left", 0.8, 0.8);
                 interpolate("controls/gear/brake-right", 0.8, 0.8);

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -53,11 +53,26 @@ var autobrake = {
                     me.fullthrottle = 0;
                 }
             }
-
-            if (getprop("/velocities/airspeed-kt") < 40) {
-                setprop("/controls/autobrake/setting", 0);
-            }
         }
+
+		# Deactivate autobrake after rollout, even from RTO. There's some slack for the throttle
+		# setting to taxi after rollout.
+		if (
+			(getprop("/velocities/airspeed-kt") < 40)
+			and (getprop("/gear/gear[0]/rollspeed-ms") > 5)
+			and (getprop("/controls/engines/engine[0]/throttle") < 0.3)
+		) {
+			setprop("/controls/autobrake/setting", 0);
+		}
+
+		# Deactivate autobrake after takeoff
+		if (
+			(getprop("/velocities/airspeed-kt") > 120)
+			and (getprop("/gear/gear[0]/compression-norm") == 0)
+			and (getprop("/controls/engines/engine[0]/throttle") > 0.9)
+		) {
+			setprop("/controls/autobrake/setting", 0);
+		}
     },
     reset : func {
         me.loopid += 1;

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -23,8 +23,8 @@ var autobrake = {
             and (getprop("gear/gear[1]/rollspeed-ms") > 5)
             # The wheels will only be spinning if the aircraft has touched down.
         ) {
-            setprop("controls/gear/brake-left", 0);
-            setprop("controls/gear/brake-right", 0);
+            interpolate("controls/gear/brake-left", 0, (absetting - 1) / 5.0 / 2);
+            interpolate("controls/gear/brake-right", 0, (absetting - 1) / 5.0 / 2);
             setprop("controls/autobrake/setting", 1);
             #screen.log.write("Disarming Autobrakes after go-around"); # For testing
         }
@@ -85,8 +85,8 @@ var autobrake = {
                 and (current_throttle == 0)
             ) {
                 #screen.log.write("Applying autobrakes after RTO"); # For testing
-                setprop("controls/gear/brake-left", 1);
-                setprop("controls/gear/brake-right", 1);
+                interpolate("controls/gear/brake-left", 1, 0.8);
+                interpolate("controls/gear/brake-right", 1, 0.8);
             }
 
             return;
@@ -102,23 +102,23 @@ var autobrake = {
             # sloped runways, so instead we detect that the nose wheel is touching the ground.
             if (getprop("gear/gear[0]/compression-ft") == 0) {
                 #screen.log.write("Setting Autobrakes to 0.8 MAX"); # For testing
-                setprop("controls/gear/brake-left", 0.8);
-                setprop("controls/gear/brake-right", 0.8);
+                interpolate("controls/gear/brake-left", 0.8, 0.8);
+                interpolate("controls/gear/brake-right", 0.8, 0.8);
                 return;
             }
 
             # Set the brakes to MAX after nose wheel touches the ground.
             #screen.log.write("Setting Autobrakes to 1.0 MAX"); # For testing
-            setprop("controls/gear/brake-left", 1);
-            setprop("controls/gear/brake-right", 1);
+            interpolate("controls/gear/brake-left", 1, 0.2);
+            interpolate("controls/gear/brake-right", 1, 0.2);
 
             return;
         }
 
         # All remaining autobrake settings
         #screen.log.write("Setting autobrakes to " ~ (absetting - 1) / 5.0 ~ "."); # For testing
-        setprop("controls/gear/brake-left", (absetting - 1) / 5.0);
-        setprop("controls/gear/brake-right", (absetting - 1) / 5.0);
+        interpolate("controls/gear/brake-left", (absetting - 1) / 5.0, (absetting - 1) / 5.0));
+        interpolate("controls/gear/brake-right", (absetting - 1) / 5.0, (absetting - 1) / 5.0));
 
         # The brakes will stay applied until coming to a complete stop or until it's disarmed.
     },

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -1,69 +1,64 @@
 var autobrake = {
-	init : func { 
-        me.UPDATE_INTERVAL = 0.5; 
-        me.loopid = 0; 
-	me.fullthrottle = 0;
-setprop("/controls/autobrake/setting", 0);
+    init : func {
+        me.UPDATE_INTERVAL = 0.5;
+        me.loopid = 0;
+        me.fullthrottle = 0;
+        setprop("/controls/autobrake/setting", 0);
 
-        me.reset(); 
-}, 
-	update : func {
+        me.reset();
+    },
+    update : func {
+        var absetting = getprop("/controls/autobrake/setting");
 
-var absetting = getprop("/controls/autobrake/setting");
+        if ((getprop("/velocities/airspeed-kt") >= 40) and (getprop("/gear/gear[0]/rollspeed-ms") > 5)) {
+            # ABS LOW 1
+            if (absetting == 1) {
+                setprop("controls/gear/brake-left", 0.2);
+                setprop("controls/gear/brake-right", 0.2);
+            }
 
-if ((getprop("/velocities/airspeed-kt") >= 40) and (getprop("/gear/gear[0]/rollspeed-ms") > 5)) {
+            # ABS LOW 2
+            if (absetting == 2) {
+                setprop("controls/gear/brake-left", 0.4);
+                setprop("controls/gear/brake-right", 0.4);
+            }
 
-# ABS LOW 1
-if (absetting == 1) {
-setprop("controls/gear/brake-left", 0.2);
-setprop("controls/gear/brake-right", 0.2);
-}
+            # ABS MED 3
+            if (absetting == 3) {
+                setprop("controls/gear/brake-left", 0.6);
+                setprop("controls/gear/brake-right", 0.6);
+            }
 
-# ABS LOW 2
-if (absetting == 2) {
-setprop("controls/gear/brake-left", 0.4);
-setprop("controls/gear/brake-right", 0.4);
-}
+            # ABS HIGH 4
+                if (absetting == 4) {
+                setprop("controls/gear/brake-left", 0.8);
+                setprop("controls/gear/brake-right", 0.8);
+            }
 
-# ABS MED 3
-if (absetting == 3) {
-setprop("controls/gear/brake-left", 0.6);
-setprop("controls/gear/brake-right", 0.6);
-}
+            # ABS MAX 5
+            if (absetting == 5) {
+                setprop("controls/gear/brake-left", 1);
+                setprop("controls/gear/brake-right", 1);
+            }
 
-# ABS HIGH 4
-if (absetting == 4) {
-setprop("controls/gear/brake-left", 0.8);
-setprop("controls/gear/brake-right", 0.8);
-}
+            # ABS RTO
+            if (absetting == 6) {
+                if (getprop("controls/engines/engine[0]/throttle") >= 0.9) {
+                    me.fullthrottle = 1;
+                }
 
-# ABS MAX 5
-if (absetting == 5) {
-setprop("controls/gear/brake-left", 1);
-setprop("controls/gear/brake-right", 1);
-}
+                if ((me.fullthrottle == 1) and (getprop("controls/engines/engine[0]/throttle") <= 0.6)) {
+                    setprop("controls/gear/brake-left", 1);
+                    setprop("controls/gear/brake-right", 1);
+                    me.fullthrottle = 0;
+                }
+            }
 
-# ABS RTO
-if (absetting == 6) {
-if (getprop("controls/engines/engine[0]/throttle") >= 0.9) {
-me.fullthrottle = 1;
-}
-
-if ((me.fullthrottle == 1) and (getprop("controls/engines/engine[0]/throttle") <= 0.6)) {
-setprop("controls/gear/brake-left", 1);
-setprop("controls/gear/brake-right", 1);
-me.fullthrottle = 0;
-}
-
-}
-
-if (getprop("/velocities/airspeed-kt") < 40) {
-    setprop("/controls/autobrake/setting", 0);
-}
-
-}
-
-},
+            if (getprop("/velocities/airspeed-kt") < 40) {
+                setprop("/controls/autobrake/setting", 0);
+            }
+        }
+    },
     reset : func {
         me.loopid += 1;
         me._loop_(me.loopid);
@@ -73,12 +68,10 @@ if (getprop("/velocities/airspeed-kt") < 40) {
         me.update();
         settimer(func { me._loop_(id); }, me.UPDATE_INTERVAL);
     }
-
 };
 
-setlistener("sim/signals/fdm-initialized", func
- {
- autobrake.init();
- print("Autobrake System .... Initialized");
- sysinfo.log_msg("[ABS] Autobrake System Initialized", 0); 
- });
+setlistener("sim/signals/fdm-initialized", func {
+    autobrake.init();
+    print("Autobrake System .... Initialized");
+    sysinfo.log_msg("[ABS] Autobrake System Initialized", 0);
+});

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -2,14 +2,20 @@ var autobrake = {
     init : func {
         me.UPDATE_INTERVAL = 0.5;
         me.loopid = 0;
-        me.old_throttle = getprop("controls/engine[0]/throttle");
+        me.old_throttle = getprop("controls/engines/engine[0]/throttle");
         me.current_spdbrk = getprop("controls/flight/speedbrake-lever");
         setprop("controls/autobrake/setting", 0);
+
+        # These only assist the auto spoilers
+        me.old_throttle1 = getprop("controls/engines/engine[0]/throttle");
+        me.old_throttle2 = getprop("controls/engines/engine[0]/throttle");
 
         me.reset();
     },
     update : func {
-        var current_throttle = getprop("controls/engines/engine[0]/throttle");
+        var throttle1 = getprop("controls/engines/engine[0]/throttle");
+        var throttle2 = getprop("controls/engines/engine[1]/throttle");
+        var current_throttle = (throttle1 + throttle2) / 2;
         var current_spdbrk = getprop("controls/flight/speedbrake-lever");
         var absetting = getprop("controls/autobrake/setting");
 
@@ -19,6 +25,19 @@ var autobrake = {
             rear_spin = getprop("gear/gear[2]/rollspeed-ms");
 
         var brake_pressure = (absetting - 1) / 5.0;
+
+        # Assist automatic spoilers system (since autobrake.nas can, in fact, know the previous
+        # state of the throttle, when the auto spoilers alone can't)
+        if (
+            (throttle1 < 0.5 and me.old_throttle1 >= 0.5)
+            or (throttle2 < 0.5 and me.old_throttle2 >= 0.5)
+        ) {
+            setprop("/controls/autobrake/possible-rto", 1);
+        } else {
+            setprop("/controls/autobrake/possible-rto", 0);
+        }
+        me.old_throttle1 = throttle1;
+        me.old_throttle2 = throttle2;
 
         # Handle disarming events
         #########################

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -42,7 +42,7 @@ var autobrake = {
             }
 
             # ABS RTO
-            if (absetting == 6) {
+            if (absetting == -1) {
                 if (getprop("controls/engines/engine[0]/throttle") >= 0.9) {
                     me.fullthrottle = 1;
                 }

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -13,6 +13,9 @@ var autobrake = {
         var current_spdbrk = getprop("controls/flight/speedbrake-lever");
         var absetting = getprop("controls/autobrake/setting");
 
+        # The pressure will be interpolated to go from 0 to 1 in 1 second (or, for eg, 0 to 0.2 in 0.2 seconds)
+        var brake_pressure = (absetting - 1) / 5.0;
+
         # Handle disarming events
         #########################
 
@@ -23,8 +26,8 @@ var autobrake = {
             and (getprop("gear/gear[1]/rollspeed-ms") > 5)
             # The wheels will only be spinning if the aircraft has touched down.
         ) {
-            interpolate("controls/gear/brake-left", 0, (absetting - 1) / 5.0 / 2);
-            interpolate("controls/gear/brake-right", 0, (absetting - 1) / 5.0 / 2);
+            interpolate("controls/gear/brake-left", 0, brake_pressure / 2);
+            interpolate("controls/gear/brake-right", 0, brake_pressure / 2);
             setprop("controls/autobrake/setting", 1);
             #screen.log.write("Disarming Autobrakes after go-around"); # For testing
         }
@@ -116,9 +119,9 @@ var autobrake = {
         }
 
         # All remaining autobrake settings
-        #screen.log.write("Setting autobrakes to " ~ (absetting - 1) / 5.0 ~ "."); # For testing
-        interpolate("controls/gear/brake-left", (absetting - 1) / 5.0, (absetting - 1) / 5.0));
-        interpolate("controls/gear/brake-right", (absetting - 1) / 5.0, (absetting - 1) / 5.0));
+        #screen.log.write("Setting autobrakes to " ~ brake_pressure ~ "."); # For testing
+        interpolate("controls/gear/brake-left", brake_pressure, brake_pressure));
+        interpolate("controls/gear/brake-right", brake_pressure, brake_pressure));
 
         # The brakes will stay applied until coming to a complete stop or until it's disarmed.
     },

--- a/Nasal/autobrake.nas
+++ b/Nasal/autobrake.nas
@@ -26,9 +26,9 @@ var autobrake = {
 
         # Initiating a go-around after touchdown disarms the system.
         if (
-            (absetting > 1)
-            and (current_throttle > me.old_throttle)
-            and (rear_spin > 5)
+            absetting > 1
+            and current_throttle > me.old_throttle
+            and rear_spin > 5
             # The wheels will only be spinning if the aircraft has touched down.
         ) {
             interpolate("controls/gear/brake-left", 0, brake_pressure / 2);
@@ -39,8 +39,8 @@ var autobrake = {
 
         # Pressing the pedal brakes when the system is armed disarms the system.
         if (
-            (absetting > 1)
-            and (getprop("controls/gear/brake-left") > (absetting - 1) / 5)
+            absetting > 1
+            and getprop("controls/gear/brake-left") > (absetting - 1) / 5
         ) {
             setprop("controls/autobrake/setting", 1);
 
@@ -54,9 +54,9 @@ var autobrake = {
         # the system.
         if (
             rear_on_ground
-            and (getprop("controls/gear/brake-left") > 0)
-            and (me.old_spdbrk > 0)
-            and (current_spdbrk == 0)
+            and getprop("controls/gear/brake-left") > 0
+            and me.old_spdbrk > 0
+            and current_spdbrk == 0
         ) {
             setprop("controls/autobrake/setting", 1);
             #screen.log.write("Disarming Autobrakes after speedbrakes down"); # For testing
@@ -72,7 +72,7 @@ var autobrake = {
         ######################################
 
         # OFF & DISARM settings
-        if ((absetting == 0) or (absetting == 1))
+        if (absetting == 0 or absetting == 1)
             return;
 
         # The wheels must be spinning to appy brakes
@@ -89,8 +89,8 @@ var autobrake = {
 
             # 43.5 rollspeed means 85 kt ground speed
             if (
-                (rear_spin > 43.5)
-                and (current_throttle == 0)
+                rear_spin > 43.5
+                and current_throttle == 0
             ) {
                 #screen.log.write("Applying autobrakes after RTO"); # For testing
                 interpolate("controls/gear/brake-left", 1, 0.8);
@@ -101,7 +101,7 @@ var autobrake = {
         }
 
         # Throttle has to be set to idle to apply brake pressure.
-        if ((current_throttle != 0))
+        if (current_throttle != 0)
             return;
 
         # AUTOBRAKE MAX setting

--- a/Systems/b787-spoilers.xml
+++ b/Systems/b787-spoilers.xml
@@ -3,83 +3,121 @@
 <!-- Boeing 787 speedbrake/ground spoiler configuration -->
 
 <PropertyList>
-
     <logic>
-        <name>Ground spoilers disarm</name>
+        <name>Set spoilers UP when lever in ARMED, on ground, and no throttles in T/O range</name>
         <enable>
             <condition>
-                <!-- Ground spoilers can only be armed when the speedbrake lever is up -->
-                <greater-than>
-                    <property>/controls/flight/speedbrake-lever</property>
-                    <value>0</value>
-                </greater-than>
-            </condition>
-        </enable>
-        <input>
-            <false />
-        </input>
-        <output>/controls/flight/ground-spoilers-armed</output>
-    </logic>
-
-    <logic>
-        <name>Ground spoilers engage</name>
-        <enable>
-            <condition>
+                <property>/gear/gear[1]/wow</property>
+                <property>/gear/gear[2]/wow</property>
                 <equals>
                     <property>/controls/flight/ground-spoilers-armed</property>
                     <value type="bool">true</value>
                 </equals>
-                <equals>
-                    <property>/controls/engines/throttle-cmd-pid</property>
-                    <value type="double">0</value>
-                </equals>
-                <property>/gear/gear[1]/wow</property>
-                <property>/gear/gear[2]/wow</property>
-                <greater-than>
-                    <property>/instrumentation/airspeed-indicator/indicated-speed-kt</property>
-                    <value>72</value>
-                </greater-than>
+                <and>
+                    <less-than>
+                        <property>/controls/engines/engine[0]/throttle</property>
+                        <value type="double">0.5</value>
+                    </less-than>
+                    <less-than>
+                        <property>/controls/engines/engine[0]/throttle</property>
+                        <value type="double">0.5</value>
+                    </less-than>
+                </and>
             </condition>
         </enable>
         <input>
-            <true />
+            <value type="double">1</value>
         </input>
-        <output>/controls/flight/ground-spoilers</output>
+        <output>/controls/flight/speedbrake-lever</output>
     </logic>
 
     <logic>
-        <name>Ground spoilers disengage</name>
+        <name>Set spoilers UP when on ground and reversers deployed</name>
         <enable>
             <condition>
+                <property>/gear/gear[1]/wow</property>
+                <property>/gear/gear[2]/wow</property>
+                <and>
+                    <property>/controls/engines/engine[0]/reverser</property>
+                    <property>/controls/engines/engine[1]/reverser</property>
+                </and>
+            </condition>
+        </enable>
+        <input>
+            <value type="double">1</value>
+        </input>
+        <output>/controls/flight/speedbrake-lever</output>
+    </logic>
+
+    <logic>
+        <name>Set spoilers UP when on ground, above 85 kt and either throttle not in T/O range (RTO)</name>
+        <enable>
+            <condition>
+                <property>/gear/gear[1]/wow</property>
+                <property>/gear/gear[2]/wow</property>
+                <equals>
+                    <!-- Use IT-AUTOFLIGHT to determine if we're on T/O CLB (and not ROLLOUT) -->
+                    <property>/it-autoflight/output/vert</property>
+                    <value type="int">7</value>
+                </equals>
+                <greater-than>
+                    <expression>
+                        <max>
+                            <property>/gear/gear[1]/rollspeed-ms</property>
+                            <property>/gear/gear[2]/rollspeed-ms</property>
+                        </max>
+                    </expression>
+                    <value>43.5</value>
+                </greater-than>
                 <or>
-                    <equals>
-                        <property>/controls/flight/ground-spoilers-armed</property>
-                        <value type="bool">false</value>
-                    </equals>
                     <less-than>
-                        <property>/instrumentation/airspeed-indicator/indicated-speed-kt</property>
-                        <value>72</value>
+                        <property>/controls/engines/engine[0]/throttle</property>
+                        <value type="double">0.5</value>
+                    </less-than>
+                    <less-than>
+                        <property>/controls/engines/engine[0]/throttle</property>
+                        <value type="double">0.5</value>
                     </less-than>
                 </or>
             </condition>
         </enable>
         <input>
-            <false />
+            <value type="double">1</value>
         </input>
-        <output>/controls/flight/ground-spoilers</output>
+        <output>/controls/flight/speedbrake-lever</output>
     </logic>
+
+    <!-- For the life of me... I can't figure out why (the f*) this deploys speedbrakes when throttle is above 50%. Signed: nico-castell -->
+    <!-- <logic>
+        <name>Set spoilers DOWN when on ground and either throttle is in T/O range</name>
+        <enable>
+            <condition>
+                <property>/gear/gear[1]/wow</property>
+                <property>/gear/gear[2]/wow</property>
+                <or>
+                    <greater-than-equals>
+                        <property>/controls/engines/engine[0]/throttle</property>
+                        <value type="double">0.5</value>
+                    </greater-than-equals>
+                    <greater-than-equals>
+                        <property>/controls/engines/engine[0]/throttle</property>
+                        <value type="double">0.5</value>
+                    </greater-than-equals>
+                </or>
+            </condition>
+        </enable>
+        <input>
+            <value type="double">0</value>
+        </input>
+        <output>/controls/flight/speedbrake-lever</output>
+    </logic> -->
 
     <filter>
         <name>Main speedbrake controller</name>
         <type>gain</type>
         <gain>1.0</gain>
         <input>
-            <expression>
-                <max>
-                    <property>/controls/flight/ground-spoilers</property>
-                    <property>/controls/flight/speedbrake-lever</property>
-                </max>
-            </expression>
+            <property>/controls/flight/speedbrake-lever</property>
         </input>
         <output>/controls/flight/speedbrake</output>
     </filter>
@@ -174,5 +212,4 @@
         <output>/systems/cac/inlet-deflector-door-pos</output>
         <max-rate-of-change>1</max-rate-of-change>
     </filter>
-
 </PropertyList>

--- a/Systems/b787-spoilers.xml
+++ b/Systems/b787-spoilers.xml
@@ -9,20 +9,15 @@
             <condition>
                 <property>/gear/gear[1]/wow</property>
                 <property>/gear/gear[2]/wow</property>
-                <equals>
-                    <property>/controls/flight/ground-spoilers-armed</property>
-                    <value type="bool">true</value>
-                </equals>
-                <and>
-                    <less-than>
-                        <property>/controls/engines/engine[0]/throttle</property>
-                        <value type="double">0.5</value>
-                    </less-than>
-                    <less-than>
-                        <property>/controls/engines/engine[0]/throttle</property>
-                        <value type="double">0.5</value>
-                    </less-than>
-                </and>
+                <property>/controls/flight/ground-spoilers-armed</property>
+                <less-than>
+                    <property>/controls/engines/engine[0]/throttle</property>
+                    <value type="double">0.5</value>
+                </less-than>
+                <less-than>
+                    <property>/controls/engines/engine[0]/throttle</property>
+                    <value type="double">0.5</value>
+                </less-than>
             </condition>
         </enable>
         <input>
@@ -37,10 +32,8 @@
             <condition>
                 <property>/gear/gear[1]/wow</property>
                 <property>/gear/gear[2]/wow</property>
-                <and>
-                    <property>/controls/engines/engine[0]/reverser</property>
-                    <property>/controls/engines/engine[1]/reverser</property>
-                </and>
+                <property>/controls/engines/engine[0]/reverser</property>
+                <property>/controls/engines/engine[1]/reverser</property>
             </condition>
         </enable>
         <input>

--- a/Systems/b787-spoilers.xml
+++ b/Systems/b787-spoilers.xml
@@ -23,7 +23,7 @@
         <input>
             <value type="double">1</value>
         </input>
-        <output>/controls/flight/speedbrake-lever</output>
+        <output>/controls/flight/speedbrake-auto</output>
     </logic>
 
     <logic>
@@ -39,7 +39,7 @@
         <input>
             <value type="double">1</value>
         </input>
-        <output>/controls/flight/speedbrake-lever</output>
+        <output>/controls/flight/speedbrake-auto</output>
     </logic>
 
     <logic>
@@ -77,7 +77,7 @@
         <input>
             <value type="double">1</value>
         </input>
-        <output>/controls/flight/speedbrake-lever</output>
+        <output>/controls/flight/speedbrake-auto</output>
     </logic>
 
     <!-- For the life of me... I can't figure out why (the f*) this deploys speedbrakes when throttle is above 50%. Signed: nico-castell -->
@@ -102,7 +102,7 @@
         <input>
             <value type="double">0</value>
         </input>
-        <output>/controls/flight/speedbrake-lever</output>
+        <output>/controls/flight/speedbrake-auto</output>
     </logic> -->
 
     <filter>
@@ -110,7 +110,12 @@
         <type>gain</type>
         <gain>1.0</gain>
         <input>
-            <property>/controls/flight/speedbrake-lever</property>
+            <expression>
+                <max>
+                    <property>/controls/flight/speedbrake-lever</property>
+                    <property>/controls/flight/speedbrake-auto</property>
+                </max>
+            </expression>
         </input>
         <output>/controls/flight/speedbrake</output>
     </filter>

--- a/Systems/b787-spoilers.xml
+++ b/Systems/b787-spoilers.xml
@@ -67,8 +67,7 @@
         <output>/controls/flight/speedbrake-auto</output>
     </logic>
 
-    <!-- For the life of me... I can't figure out why (the f*) this deploys speedbrakes when throttle is above 50%. Signed: nico-castell -->
-    <!-- <logic>
+    <logic>
         <name>Set spoilers DOWN when on ground and either throttle is in T/O range</name>
         <enable>
             <condition>
@@ -90,7 +89,7 @@
             <false />
         </input>
         <output>/controls/flight/speedbrake-auto</output>
-    </logic> -->
+    </logic>
 
     <filter>
         <name>Main speedbrake controller</name>

--- a/Systems/b787-spoilers.xml
+++ b/Systems/b787-spoilers.xml
@@ -4,7 +4,7 @@
 
 <PropertyList>
     <logic>
-        <name>Set spoilers UP when lever in ARMED, on ground, and no throttles in T/O range</name>
+        <name>Set spoilers UP when on ground, lever in ARMED, spd above 70kt, and no throttles above 50%</name>
         <enable>
             <condition>
                 <property>/gear/gear[1]/wow</property>
@@ -21,13 +21,13 @@
             </condition>
         </enable>
         <input>
-            <value type="double">1</value>
+            <true />
         </input>
         <output>/controls/flight/speedbrake-auto</output>
     </logic>
 
     <logic>
-        <name>Set spoilers UP when on ground and reversers deployed</name>
+        <name>Set spoilers UP when on ground, spd above 70 kt, and reversers deployed</name>
         <enable>
             <condition>
                 <property>/gear/gear[1]/wow</property>
@@ -37,7 +37,7 @@
             </condition>
         </enable>
         <input>
-            <value type="double">1</value>
+            <true />
         </input>
         <output>/controls/flight/speedbrake-auto</output>
     </logic>
@@ -75,7 +75,7 @@
             </condition>
         </enable>
         <input>
-            <value type="double">1</value>
+            <true />
         </input>
         <output>/controls/flight/speedbrake-auto</output>
     </logic>
@@ -100,7 +100,7 @@
             </condition>
         </enable>
         <input>
-            <value type="double">0</value>
+            <false />
         </input>
         <output>/controls/flight/speedbrake-auto</output>
     </logic> -->

--- a/Systems/b787-spoilers.xml
+++ b/Systems/b787-spoilers.xml
@@ -48,11 +48,8 @@
             <condition>
                 <property>/gear/gear[1]/wow</property>
                 <property>/gear/gear[2]/wow</property>
-                <equals>
-                    <!-- Use IT-AUTOFLIGHT to determine if we're on T/O CLB (and not ROLLOUT) -->
-                    <property>/it-autoflight/output/vert</property>
-                    <value type="int">7</value>
-                </equals>
+                <!-- Use an assist by the autobrake system to detect RTOs by monitoring throttles -->
+                <property>/controls/autobrake/possible-rto</property>
                 <greater-than>
                     <expression>
                         <max>
@@ -62,16 +59,6 @@
                     </expression>
                     <value>43.5</value>
                 </greater-than>
-                <or>
-                    <less-than>
-                        <property>/controls/engines/engine[0]/throttle</property>
-                        <value type="double">0.5</value>
-                    </less-than>
-                    <less-than>
-                        <property>/controls/engines/engine[0]/throttle</property>
-                        <value type="double">0.5</value>
-                    </less-than>
-                </or>
             </condition>
         </enable>
         <input>

--- a/Systems/b787-spoilers.xml
+++ b/Systems/b787-spoilers.xml
@@ -4,7 +4,7 @@
 
 <PropertyList>
     <logic>
-        <name>Set spoilers UP when on ground, lever in ARMED, spd above 70kt, and no throttles above 50%</name>
+        <name>Set spoilers UP when on ground, lever in ARMED, and no throttles above 50%</name>
         <enable>
             <condition>
                 <property>/gear/gear[1]/wow</property>
@@ -27,7 +27,7 @@
     </logic>
 
     <logic>
-        <name>Set spoilers UP when on ground, spd above 70 kt, and reversers deployed</name>
+        <name>Set spoilers UP when on ground, and reversers deployed</name>
         <enable>
             <condition>
                 <property>/gear/gear[1]/wow</property>


### PR DESCRIPTION
The autobrake knob could only be used with the left click, when it could also be used with the scroll-wheel.

This PR makes that possible, and knob won't repeat the settings using the scrollwheel so you can't go from RTO to Autobrake MAX by accident if you scroll down, just like you won't go from Autobrake MAX to RTO by scrolling up.

I also did some formatting for clarity and coding in the [autobrake.nas](https://github.com/IskenderWang/787-family/pull/Nasal/autobrake.nas) file to auto-deactivate the automatic brakes after rollout and/or after takeoff.