### PR TITLE
Fixes the pushback truck's alignment with the wheels and rotation

### DIFF
--- a/Models/787-10-GEnx.xml
+++ b/Models/787-10-GEnx.xml
@@ -106,8 +106,9 @@
         <name>Pushback</name>
         <path>Autopush/Goldhofert.xml</path>
         <offsets>
-            <x-m>-25.54268</x-m>
-
+            <!-- The truck should be -0.346 x-m from the plane's nose wheel -->
+            <x-m>-27.201</x-m>
+            <y-m>0</y-m>
             <z-m>-3.55</z-m>
         </offsets>
     </model>

--- a/Models/787-10-Trent1000.xml
+++ b/Models/787-10-Trent1000.xml
@@ -106,8 +106,9 @@
         <name>Pushback</name>
         <path>Autopush/Goldhofert.xml</path>
         <offsets>
-            <x-m>-25.54268</x-m>
-
+            <!-- The truck should be -0.346 x-m from the plane's nose wheel -->
+            <x-m>-27.201</x-m>
+            <y-m>0</y-m>
             <z-m>-3.55</z-m>
         </offsets>
     </model>

--- a/Models/787-8-GEnx.xml
+++ b/Models/787-8-GEnx.xml
@@ -106,8 +106,9 @@
         <name>Pushback</name>
         <path>Autopush/Goldhofert.xml</path>
         <offsets>
-            <x-m>-25.54268</x-m>
-
+            <!-- The truck should be -0.346 x-m from the plane's nose wheel -->
+            <x-m>-20.935</x-m>
+            <y-m>0</y-m>
             <z-m>-3.55</z-m>
         </offsets>
     </model>

--- a/Models/787-8-Trent1000.xml
+++ b/Models/787-8-Trent1000.xml
@@ -106,8 +106,9 @@
         <name>Pushback</name>
         <path>Autopush/Goldhofert.xml</path>
         <offsets>
-            <x-m>-25.54268</x-m>
-
+            <!-- The truck should be -0.346 x-m from the plane's nose wheel -->
+            <x-m>-20.935</x-m>
+            <y-m>0</y-m>
             <z-m>-3.55</z-m>
         </offsets>
     </model>

--- a/Models/787-9-GEnx.xml
+++ b/Models/787-9-GEnx.xml
@@ -106,8 +106,9 @@
         <name>Pushback</name>
         <path>Autopush/Goldhofert.xml</path>
         <offsets>
-            <x-m>-25.54268</x-m>
-
+            <!-- The truck should be -0.346 x-m from the plane's nose wheel -->
+            <x-m>-24.181</x-m>
+            <y-m>0</y-m>
             <z-m>-3.55</z-m>
         </offsets>
     </model>

--- a/Models/787-9-Trent1000.xml
+++ b/Models/787-9-Trent1000.xml
@@ -106,8 +106,9 @@
         <name>Pushback</name>
         <path>Autopush/Goldhofert.xml</path>
         <offsets>
-            <x-m>-25.54268</x-m>
-
+            <!-- The truck should be -0.346 x-m from the plane's nose wheel -->
+            <x-m>-24.181</x-m>
+            <y-m>0</y-m>
             <z-m>-3.55</z-m>
         </offsets>
     </model>

--- a/Models/Autopush/Goldhofert.xml
+++ b/Models/Autopush/Goldhofert.xml
@@ -71,13 +71,13 @@ Distribute under the terms of GPLv2.
    <factor>-16.3</factor>
    <center>
      <x-m>-2.8976</x-m>
-     
+
      <z-m>0.5809</z-m>
    </center>
    <axis>
-     
+
      <y>1</y>
-     
+
    </axis>
  </animation>
 
@@ -89,13 +89,13 @@ Distribute under the terms of GPLv2.
    <factor>-16.3</factor>
    <center>
      <x-m>2.0501</x-m>
-     
+
      <z-m>0.5735</z-m>
    </center>
    <axis>
-     
+
      <y>1</y>
-     
+
    </axis>
  </animation>
 
@@ -111,14 +111,14 @@ Distribute under the terms of GPLv2.
    <property>&YAW-PROP;</property>
    <factor>&YAW-MULT;</factor>
    <center>
-     
-     
-     
+     <x-m>0.346</x-m>
+     <y-m>0</y-m>
+     <z-m>0</z-m>
    </center>
    <axis>
-     
-     
-     <z>-1</z>
+    <x>0</x>
+    <y>0</y>
+    <z>-1</z>
    </axis>
  </animation>
 
@@ -127,8 +127,8 @@ Distribute under the terms of GPLv2.
    <property>&COMPRESSION-PROP;</property>
    <factor>0.3048</factor>
    <axis>
-     
-     
+
+
      <z>1</z>
    </axis>
  </animation>
@@ -139,14 +139,14 @@ Distribute under the terms of GPLv2.
    <factor>&PITCH-FACTOR;</factor>
    <offset-deg>&PITCH-OFFSET;</offset-deg>
    <center>
-     
-     
-     
+
+
+
    </center>
    <axis>
-     
+
      <y>1</y>
-     
+
    </axis>
  </animation>
 </PropertyList>


### PR DESCRIPTION
Across the 3 variants, the pushback truck was incorrectly aligned with the wheels.

This PR fixes the alignment for the 3 variants and adjusts the truck's rotation center to keep the wheels in alignment when steering.